### PR TITLE
Fix Slow UX - Remove middleware checks

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -20,7 +20,10 @@ const store = configureStore({
     multicall,
     lists
   },
-  middleware: [...getDefaultMiddleware({ thunk: false }), save({ states: PERSISTED_KEYS })],
+  middleware: [
+    ...getDefaultMiddleware({ thunk: false, serializableCheck: false, immutableCheck: false }),
+    save({ states: PERSISTED_KEYS })
+  ],
   preloadedState: load({ states: PERSISTED_KEYS })
 })
 


### PR DESCRIPTION
The UX is extremely slow because of serializer and immutable checks in the state middleware. Removing these checks for now so it doesn't slow us down. We should revisit this later, i'll make an issue in the backlog.

Set `serializableCheck` & `immutableCheck` to `false` in the store middleware. 