### PR TITLE
ALC-268 add multi-dex support (sushiswap)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,7 +15,7 @@ export const MISTX_RELAY_URI: { [chainId in ChainId]?: string } = {
 export const ROUTER: { [exchange in Exchange]: string } = {
   [Exchange.UNI]: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
   [Exchange.SUSHI]: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9',
-  [Exchange.UNDEFINED]: '0x0',
+  [Exchange.UNDEFINED]: '0x0'
 }
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { ChainId, JSBI, Percent, Token, WETH } from '@alchemistcoin/sdk'
+import { ChainId, Exchange, JSBI, Percent, Token, WETH } from '@alchemistcoin/sdk'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 
 import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
@@ -12,7 +12,11 @@ export const MISTX_RELAY_URI: { [chainId in ChainId]?: string } = {
   [ChainId.MAINNET]: 'https://mistX' //TODO change to socket
 }
 
-export const UNI_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+export const ROUTER: { [exchange in Exchange]: string } = {
+  [Exchange.UNI]: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
+  [Exchange.SUSHI]: '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9',
+  [Exchange.UNDEFINED]: '0x0',
+}
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -16,7 +16,10 @@ export enum PairState {
   INVALID
 }
 
-export function usePairs(currencies: [Currency | undefined, Currency | undefined][], exchange: Exchange): [PairState, Pair | null][] {
+export function usePairs(
+  currencies: [Currency | undefined, Currency | undefined][],
+  exchange: Exchange
+): [PairState, Pair | null][] {
   const { chainId } = useActiveWeb3React()
 
   const tokens = useMemo(
@@ -51,12 +54,12 @@ export function usePairs(currencies: [Currency | undefined, Currency | undefined
       const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
       return [
         PairState.EXISTS,
-        new Pair(new TokenAmount(token0, reserve0.toString()), new TokenAmount(token1, reserve1.toString()), exchange),
+        new Pair(new TokenAmount(token0, reserve0.toString()), new TokenAmount(token1, reserve1.toString()), exchange)
       ]
     })
   }, [results, tokens, exchange])
 }
 
-export function usePair(exchange: Exchange, tokenA?: Currency, tokenB?: Currency, ): [PairState, Pair | null] {
+export function usePair(exchange: Exchange, tokenA?: Currency, tokenB?: Currency): [PairState, Pair | null] {
   return usePairs([[tokenA, tokenB]], exchange)[0]
 }

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -16,7 +16,7 @@ export enum PairState {
   INVALID
 }
 
-export function usePairs(currencies: [Currency | undefined, Currency | undefined][], exchange?: Exchange): [PairState, Pair | null][] {
+export function usePairs(currencies: [Currency | undefined, Currency | undefined][], exchange: Exchange): [PairState, Pair | null][] {
   const { chainId } = useActiveWeb3React()
 
   const tokens = useMemo(
@@ -57,6 +57,6 @@ export function usePairs(currencies: [Currency | undefined, Currency | undefined
   }, [results, tokens, exchange])
 }
 
-export function usePair(tokenA?: Currency, tokenB?: Currency, exchange?: Exchange): [PairState, Pair | null] {
+export function usePair(exchange: Exchange, tokenA?: Currency, tokenB?: Currency, ): [PairState, Pair | null] {
   return usePairs([[tokenA, tokenB]], exchange)[0]
 }

--- a/src/data/V1.ts
+++ b/src/data/V1.ts
@@ -4,6 +4,7 @@ import {
   Currency,
   CurrencyAmount,
   ETHER,
+  Exchange,
   JSBI,
   Pair,
   Route,
@@ -30,7 +31,7 @@ export function useV1ExchangeAddress(tokenAddress?: string): string | undefined 
 
 export class MockV1Pair extends Pair {
   constructor(etherAmount: BigintIsh, tokenAmount: TokenAmount) {
-    super(tokenAmount, new TokenAmount(WETH[tokenAmount.token.chainId], etherAmount))
+    super(tokenAmount, new TokenAmount(WETH[tokenAmount.token.chainId], etherAmount), Exchange.UNI)
   }
 }
 
@@ -126,7 +127,7 @@ export function useV1Trade(
   try {
     v1Trade =
       route && exactAmount
-        ? new Trade(route, exactAmount, isExactIn ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT)
+        ? new Trade(route, exactAmount, isExactIn ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT, Exchange.UNI)
         : undefined
   } catch (error) {
     console.debug('Failed to create V1 trade', error)

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -42,31 +42,31 @@ function useAllCommonPairs(exchange: Exchange, currencyA?: Currency, currencyB?:
     () =>
       tokenA && tokenB
         ? [
-          // the direct pair
-          [tokenA, tokenB],
-          // token A against all bases
-          ...bases.map((base): [Token, Token] => [tokenA, base]),
-          // token B against all bases
-          ...bases.map((base): [Token, Token] => [tokenB, base]),
-          // each base against all bases
-          ...basePairs
-        ]
-          .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
-          .filter(([t0, t1]) => t0.address !== t1.address)
-          .filter(([tokenA, tokenB]) => {
-            if (!chainId) return true
-            const customBases = CUSTOM_BASES[chainId]
+            // the direct pair
+            [tokenA, tokenB],
+            // token A against all bases
+            ...bases.map((base): [Token, Token] => [tokenA, base]),
+            // token B against all bases
+            ...bases.map((base): [Token, Token] => [tokenB, base]),
+            // each base against all bases
+            ...basePairs
+          ]
+            .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
+            .filter(([t0, t1]) => t0.address !== t1.address)
+            .filter(([tokenA, tokenB]) => {
+              if (!chainId) return true
+              const customBases = CUSTOM_BASES[chainId]
 
-            const customBasesA: Token[] | undefined = customBases?.[tokenA.address]
-            const customBasesB: Token[] | undefined = customBases?.[tokenB.address]
+              const customBasesA: Token[] | undefined = customBases?.[tokenA.address]
+              const customBasesB: Token[] | undefined = customBases?.[tokenB.address]
 
-            if (!customBasesA && !customBasesB) return true
+              if (!customBasesA && !customBasesB) return true
 
-            if (customBasesA && !customBasesA.find(base => tokenB.equals(base))) return false
-            if (customBasesB && !customBasesB.find(base => tokenA.equals(base))) return false
+              if (customBasesA && !customBasesA.find(base => tokenB.equals(base))) return false
+              if (customBasesB && !customBasesB.find(base => tokenA.equals(base))) return false
 
-            return true
-          })
+              return true
+            })
         : [],
     [tokenA, tokenB, bases, basePairs, chainId]
   )
@@ -95,7 +95,11 @@ const MAX_HOPS = 3
 /**
  * Returns the best trade for the exact amount of tokens in to the given token out
  */
-export function useTradeExactIn(exchange: Exchange, currencyAmountIn?: CurrencyAmount, currencyOut?: Currency): Trade | null {
+export function useTradeExactIn(
+  exchange: Exchange,
+  currencyAmountIn?: CurrencyAmount,
+  currencyOut?: Currency
+): Trade | null {
   const allowedPairs = useAllCommonPairs(exchange, currencyAmountIn?.currency, currencyOut)
 
   const [singleHopOnly] = useUserSingleHopOnly()
@@ -104,16 +108,20 @@ export function useTradeExactIn(exchange: Exchange, currencyAmountIn?: CurrencyA
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0) {
       if (singleHopOnly) {
         return (
-          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, { maxHops: 1, maxNumResults: 1 })[0] ??
-          null
+          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, {
+            maxHops: 1,
+            maxNumResults: 1
+          })[0] ?? null
         )
       }
       // search through trades with varying hops, find best trade out of them
       let bestTradeSoFar: Trade | null = null
       for (let i = 1; i <= MAX_HOPS; i++) {
         const currentTrade: Trade | null =
-          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, { maxHops: i, maxNumResults: 1 })[0] ??
-          null
+          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, {
+            maxHops: i,
+            maxNumResults: 1
+          })[0] ?? null
 
         // if current trade is best yet, save it
         if (isTradeBetter(bestTradeSoFar, currentTrade, BETTER_TRADE_LESS_HOPS_THRESHOLD)) {
@@ -130,8 +138,12 @@ export function useTradeExactIn(exchange: Exchange, currencyAmountIn?: CurrencyA
 /**
  * Returns the best trade for the token in to the exact amount of token out
  */
-export function useTradeExactOut(exchange: Exchange, currencyIn?: Currency, currencyAmountOut?: CurrencyAmount,): Trade | null {
-  const allowedPairs = useAllCommonPairs(exchange, currencyIn, currencyAmountOut?.currency,)
+export function useTradeExactOut(
+  exchange: Exchange,
+  currencyIn?: Currency,
+  currencyAmountOut?: CurrencyAmount
+): Trade | null {
+  const allowedPairs = useAllCommonPairs(exchange, currencyIn, currencyAmountOut?.currency)
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
@@ -139,16 +151,20 @@ export function useTradeExactOut(exchange: Exchange, currencyIn?: Currency, curr
     if (currencyIn && currencyAmountOut && allowedPairs.length > 0) {
       if (singleHopOnly) {
         return (
-          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, { maxHops: 1, maxNumResults: 1 })[0] ??
-          null
+          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, {
+            maxHops: 1,
+            maxNumResults: 1
+          })[0] ?? null
         )
       }
       // search through trades with varying hops, find best trade out of them
       let bestTradeSoFar: Trade | null = null
       for (let i = 1; i <= MAX_HOPS; i++) {
         const currentTrade =
-          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, { maxHops: i, maxNumResults: 1 })[0] ??
-          null
+          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, {
+            maxHops: i,
+            maxNumResults: 1
+          })[0] ?? null
         if (isTradeBetter(bestTradeSoFar, currentTrade, BETTER_TRADE_LESS_HOPS_THRESHOLD)) {
           bestTradeSoFar = currentTrade
         }

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -16,7 +16,7 @@ import { useActiveWeb3React } from './index'
 import { useUnsupportedTokens } from './Tokens'
 import { useUserSingleHopOnly } from 'state/user/hooks'
 
-function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency, exchange?: Exchange): Pair[] {
+function useAllCommonPairs(exchange: Exchange, currencyA?: Currency, currencyB?: Currency): Pair[] {
   const { chainId } = useActiveWeb3React()
 
   const [tokenA, tokenB] = chainId
@@ -95,8 +95,8 @@ const MAX_HOPS = 3
 /**
  * Returns the best trade for the exact amount of tokens in to the given token out
  */
-export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?: Currency, exchange?: Exchange): Trade | null {
-  const allowedPairs = useAllCommonPairs(currencyAmountIn?.currency, currencyOut, exchange)
+export function useTradeExactIn(exchange: Exchange, currencyAmountIn?: CurrencyAmount, currencyOut?: Currency): Trade | null {
+  const allowedPairs = useAllCommonPairs(exchange, currencyAmountIn?.currency, currencyOut)
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
@@ -104,7 +104,7 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0) {
       if (singleHopOnly) {
         return (
-          Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: 1, maxNumResults: 1 })[0] ??
+          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, { maxHops: 1, maxNumResults: 1 })[0] ??
           null
         )
       }
@@ -112,8 +112,9 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
       let bestTradeSoFar: Trade | null = null
       for (let i = 1; i <= MAX_HOPS; i++) {
         const currentTrade: Trade | null =
-          Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: i, maxNumResults: 1 })[0] ??
+          Trade.bestTradeExactIn(allowedPairs, exchange, currencyAmountIn, currencyOut, { maxHops: i, maxNumResults: 1 })[0] ??
           null
+
         // if current trade is best yet, save it
         if (isTradeBetter(bestTradeSoFar, currentTrade, BETTER_TRADE_LESS_HOPS_THRESHOLD)) {
           bestTradeSoFar = currentTrade
@@ -123,14 +124,14 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
     }
 
     return null
-  }, [allowedPairs, currencyAmountIn, currencyOut, singleHopOnly])
+  }, [allowedPairs, currencyAmountIn, currencyOut, singleHopOnly, exchange])
 }
 
 /**
  * Returns the best trade for the token in to the exact amount of token out
  */
-export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: CurrencyAmount, exchange?: Exchange): Trade | null {
-  const allowedPairs = useAllCommonPairs(currencyIn, currencyAmountOut?.currency, exchange)
+export function useTradeExactOut(exchange: Exchange, currencyIn?: Currency, currencyAmountOut?: CurrencyAmount,): Trade | null {
+  const allowedPairs = useAllCommonPairs(exchange, currencyIn, currencyAmountOut?.currency,)
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
@@ -138,7 +139,7 @@ export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: Curr
     if (currencyIn && currencyAmountOut && allowedPairs.length > 0) {
       if (singleHopOnly) {
         return (
-          Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, { maxHops: 1, maxNumResults: 1 })[0] ??
+          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, { maxHops: 1, maxNumResults: 1 })[0] ??
           null
         )
       }
@@ -146,7 +147,7 @@ export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: Curr
       let bestTradeSoFar: Trade | null = null
       for (let i = 1; i <= MAX_HOPS; i++) {
         const currentTrade =
-          Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, { maxHops: i, maxNumResults: 1 })[0] ??
+          Trade.bestTradeExactOut(allowedPairs, exchange, currencyIn, currencyAmountOut, { maxHops: i, maxNumResults: 1 })[0] ??
           null
         if (isTradeBetter(bestTradeSoFar, currentTrade, BETTER_TRADE_LESS_HOPS_THRESHOLD)) {
           bestTradeSoFar = currentTrade
@@ -155,7 +156,7 @@ export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: Curr
       return bestTradeSoFar
     }
     return null
-  }, [currencyIn, currencyAmountOut, allowedPairs, singleHopOnly])
+  }, [currencyIn, currencyAmountOut, allowedPairs, singleHopOnly, exchange])
 }
 
 export function useIsTransactionUnsupported(currencyIn?: Currency, currencyOut?: Currency): boolean {

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -1,5 +1,5 @@
 import { isTradeBetter } from 'utils/trades'
-import { Currency, CurrencyAmount, Pair, Token, Trade } from '@alchemistcoin/sdk'
+import { Currency, CurrencyAmount, Exchange, Pair, Token, Trade } from '@alchemistcoin/sdk'
 import flatMap from 'lodash.flatmap'
 import { useMemo } from 'react'
 
@@ -16,7 +16,7 @@ import { useActiveWeb3React } from './index'
 import { useUnsupportedTokens } from './Tokens'
 import { useUserSingleHopOnly } from 'state/user/hooks'
 
-function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): Pair[] {
+function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency, exchange?: Exchange): Pair[] {
   const { chainId } = useActiveWeb3React()
 
   const [tokenA, tokenB] = chainId
@@ -42,36 +42,36 @@ function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): Pair[] {
     () =>
       tokenA && tokenB
         ? [
-            // the direct pair
-            [tokenA, tokenB],
-            // token A against all bases
-            ...bases.map((base): [Token, Token] => [tokenA, base]),
-            // token B against all bases
-            ...bases.map((base): [Token, Token] => [tokenB, base]),
-            // each base against all bases
-            ...basePairs
-          ]
-            .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
-            .filter(([t0, t1]) => t0.address !== t1.address)
-            .filter(([tokenA, tokenB]) => {
-              if (!chainId) return true
-              const customBases = CUSTOM_BASES[chainId]
+          // the direct pair
+          [tokenA, tokenB],
+          // token A against all bases
+          ...bases.map((base): [Token, Token] => [tokenA, base]),
+          // token B against all bases
+          ...bases.map((base): [Token, Token] => [tokenB, base]),
+          // each base against all bases
+          ...basePairs
+        ]
+          .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
+          .filter(([t0, t1]) => t0.address !== t1.address)
+          .filter(([tokenA, tokenB]) => {
+            if (!chainId) return true
+            const customBases = CUSTOM_BASES[chainId]
 
-              const customBasesA: Token[] | undefined = customBases?.[tokenA.address]
-              const customBasesB: Token[] | undefined = customBases?.[tokenB.address]
+            const customBasesA: Token[] | undefined = customBases?.[tokenA.address]
+            const customBasesB: Token[] | undefined = customBases?.[tokenB.address]
 
-              if (!customBasesA && !customBasesB) return true
+            if (!customBasesA && !customBasesB) return true
 
-              if (customBasesA && !customBasesA.find(base => tokenB.equals(base))) return false
-              if (customBasesB && !customBasesB.find(base => tokenA.equals(base))) return false
+            if (customBasesA && !customBasesA.find(base => tokenB.equals(base))) return false
+            if (customBasesB && !customBasesB.find(base => tokenA.equals(base))) return false
 
-              return true
-            })
+            return true
+          })
         : [],
     [tokenA, tokenB, bases, basePairs, chainId]
   )
 
-  const allPairs = usePairs(allPairCombinations)
+  const allPairs = usePairs(allPairCombinations, exchange)
 
   // only pass along valid pairs, non-duplicated pairs
   return useMemo(
@@ -95,8 +95,8 @@ const MAX_HOPS = 3
 /**
  * Returns the best trade for the exact amount of tokens in to the given token out
  */
-export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?: Currency): Trade | null {
-  const allowedPairs = useAllCommonPairs(currencyAmountIn?.currency, currencyOut)
+export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?: Currency, exchange?: Exchange): Trade | null {
+  const allowedPairs = useAllCommonPairs(currencyAmountIn?.currency, currencyOut, exchange)
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
@@ -129,8 +129,8 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
 /**
  * Returns the best trade for the token in to the exact amount of token out
  */
-export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: CurrencyAmount): Trade | null {
-  const allowedPairs = useAllCommonPairs(currencyIn, currencyAmountOut?.currency)
+export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: CurrencyAmount, exchange?: Exchange): Trade | null {
+  const allowedPairs = useAllCommonPairs(currencyIn, currencyAmountOut?.currency, exchange)
 
   const [singleHopOnly] = useUserSingleHopOnly()
 

--- a/src/hooks/useSwapCallArguments.ts
+++ b/src/hooks/useSwapCallArguments.ts
@@ -61,7 +61,7 @@ function useModifiedTrade(
     currencyOut = trade.outputAmount.currency
     currencyAmountOut = new TokenAmount(currencyOut as Token, JSBI.BigInt(1))
   }
-  const exchange =  trade ? trade.exchange : Exchange.UNDEFINED
+  const exchange = trade ? trade.exchange : Exchange.UNDEFINED
   const modifiedExactInTrade = useTradeExactIn(exchange, currencyAmountIn, currencyOut)
   const modifiedExactOutTrade = useTradeExactOut(exchange, currencyInEth, currencyAmountOut)
   if (trade?.tradeType === TradeType.EXACT_INPUT) {

--- a/src/hooks/useSwapCallArguments.ts
+++ b/src/hooks/useSwapCallArguments.ts
@@ -53,7 +53,6 @@ function useModifiedTrade(
   let modifiedTrade: Trade | undefined
   let currencyAmountOut: CurrencyAmount | undefined
   let currencyOut: Currency | undefined
-  let exchange : Exchange
 
   if (trade && trade.inputAmount.currency.symbol !== currencyInEth.symbol) {
     currencyOut = trade.inputAmount.currency
@@ -62,7 +61,7 @@ function useModifiedTrade(
     currencyOut = trade.outputAmount.currency
     currencyAmountOut = new TokenAmount(currencyOut as Token, JSBI.BigInt(1))
   }
-  exchange =  trade ? trade.exchange : Exchange.UNDEFINED
+  const exchange =  trade ? trade.exchange : Exchange.UNDEFINED
   const modifiedExactInTrade = useTradeExactIn(exchange, currencyAmountIn, currencyOut)
   const modifiedExactOutTrade = useTradeExactOut(exchange, currencyInEth, currencyAmountOut)
   if (trade?.tradeType === TradeType.EXACT_INPUT) {

--- a/src/hooks/useSwapCallArguments.ts
+++ b/src/hooks/useSwapCallArguments.ts
@@ -9,7 +9,8 @@ import {
   Currency,
   CurrencyAmount,
   TokenAmount,
-  Token
+  Token,
+  Exchange
 } from '@alchemistcoin/sdk'
 import { useMemo } from 'react'
 import { useCurrency } from './Tokens'
@@ -52,6 +53,7 @@ function useModifiedTrade(
   let modifiedTrade: Trade | undefined
   let currencyAmountOut: CurrencyAmount | undefined
   let currencyOut: Currency | undefined
+  let exchange : Exchange
 
   if (trade && trade.inputAmount.currency.symbol !== currencyInEth.symbol) {
     currencyOut = trade.inputAmount.currency
@@ -60,8 +62,9 @@ function useModifiedTrade(
     currencyOut = trade.outputAmount.currency
     currencyAmountOut = new TokenAmount(currencyOut as Token, JSBI.BigInt(1))
   }
-  const modifiedExactInTrade = useTradeExactIn(currencyAmountIn, currencyOut)
-  const modifiedExactOutTrade = useTradeExactOut(currencyInEth, currencyAmountOut)
+  exchange =  trade ? trade.exchange : Exchange.UNDEFINED
+  const modifiedExactInTrade = useTradeExactIn(exchange, currencyAmountIn, currencyOut)
+  const modifiedExactOutTrade = useTradeExactOut(exchange, currencyInEth, currencyAmountOut)
   if (trade?.tradeType === TradeType.EXACT_INPUT) {
     modifiedTrade = modifiedExactOutTrade || undefined
   }

--- a/src/hooks/useSwapCallArguments.ts
+++ b/src/hooks/useSwapCallArguments.ts
@@ -53,7 +53,7 @@ function useModifiedTrade(
   let modifiedTrade: Trade | undefined
   let currencyAmountOut: CurrencyAmount | undefined
   let currencyOut: Currency | undefined
-  let exchange : Exchange
+  let exchange: Exchange
 
   if (trade && trade.inputAmount.currency.symbol !== currencyInEth.symbol) {
     currencyOut = trade.inputAmount.currency
@@ -62,7 +62,7 @@ function useModifiedTrade(
     currencyOut = trade.outputAmount.currency
     currencyAmountOut = new TokenAmount(currencyOut as Token, JSBI.BigInt(1))
   }
-  exchange =  trade ? trade.exchange : Exchange.UNDEFINED
+  exchange = trade ? trade.exchange : Exchange.UNDEFINED
   const modifiedExactInTrade = useTradeExactIn(exchange, currencyAmountIn, currencyOut)
   const modifiedExactOutTrade = useTradeExactOut(exchange, currencyInEth, currencyAmountOut)
   if (trade?.tradeType === TradeType.EXACT_INPUT) {

--- a/src/hooks/useSwapCallArguments.ts
+++ b/src/hooks/useSwapCallArguments.ts
@@ -60,7 +60,6 @@ function useModifiedTrade(
     currencyOut = trade.outputAmount.currency
     currencyAmountOut = new TokenAmount(currencyOut as Token, JSBI.BigInt(1))
   }
-
   const modifiedExactInTrade = useTradeExactIn(currencyAmountIn, currencyOut)
   const modifiedExactOutTrade = useTradeExactOut(currencyInEth, currencyAmountOut)
   if (trade?.tradeType === TradeType.EXACT_INPUT) {

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -6,7 +6,7 @@ import { calculateGasMargin /*, isAddress, shortenAddress*/ } from '../utils'
 import isZero from '../utils/isZero'
 import { useActiveWeb3React } from './index'
 import useENS from './useENS'
-import { /*MISTX_RELAY_URI, */ INITIAL_ALLOWED_SLIPPAGE, UNI_ROUTER_ADDRESS } from '../constants'
+import { /*MISTX_RELAY_URI, */ INITIAL_ALLOWED_SLIPPAGE, ROUTER } from '../constants'
 import { ethers } from 'ethers'
 import { keccak256 } from 'ethers/lib/utils'
 import { SignatureLike } from '@ethersproject/bytes'
@@ -112,8 +112,8 @@ export function useSwapCallback(
                   signedApproval === undefined
                     ? contract.signer.getTransactionCount()
                     : contract.signer.getTransactionCount().then(nonce => {
-                        return nonce + 1
-                      }),
+                      return nonce + 1
+                    }),
                 gasLimit: calculateGasMargin(gasEstimate), //needed?
                 ...(value && !isZero(value) ? { value } : {})
               })
@@ -163,7 +163,7 @@ export function useSwapCallback(
                         serializedSwap: signedTx,
                         swap: swapReq,
                         bribe: '0', // need to use calculated bribe
-                        routerAddress: UNI_ROUTER_ADDRESS,
+                        routerAddress: ROUTER[trade.exchange],
                         ttl: Math.floor(transactionTTL * 60 * 1000) // convert to milliseconds
                       }
 

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -112,8 +112,8 @@ export function useSwapCallback(
                   signedApproval === undefined
                     ? contract.signer.getTransactionCount()
                     : contract.signer.getTransactionCount().then(nonce => {
-                      return nonce + 1
-                    }),
+                        return nonce + 1
+                      }),
                 gasLimit: calculateGasMargin(gasEstimate), //needed?
                 ...(value && !isZero(value) ? { value } : {})
               })

--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -1,4 +1,4 @@
-import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount, WETH, Pair } from '@alchemistcoin/sdk'
+import { ChainId, CurrencyAmount, JSBI, Token, TokenAmount, WETH, Pair, Exchange } from '@alchemistcoin/sdk'
 import { useMemo } from 'react'
 import { DAI, UNI, USDC, USDT, WBTC } from '../../constants'
 import { STAKING_REWARDS_INTERFACE } from '../../constants/abis/staking-rewards'
@@ -153,7 +153,7 @@ export function useStakingInfo(pairToFilterBy?: Pair | null): StakingInfo[] {
 
         // get the LP token
         const tokens = info[index].tokens
-        const dummyPair = new Pair(new TokenAmount(tokens[0], '0'), new TokenAmount(tokens[1], '0'))
+        const dummyPair = new Pair(new TokenAmount(tokens[0], '0'), new TokenAmount(tokens[1], '0'), Exchange.UNI)
 
         // check for account, if no account set to 0
 

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -139,6 +139,28 @@ export function useDerivedSwapInfo(): {
 
   const isExactIn: boolean = independentField === Field.INPUT
   const parsedAmount = tryParseAmount(typedValue, (isExactIn ? inputCurrency : outputCurrency) ?? undefined)
+
+  //iterate so we can compare universally - fails because of react hooks inside loop
+  //let bestTradeExactInEx: { [exchange: number]: { trade: Trade | null } } = {}, bestTradeExactOutEx: { [exchange: number]: { trade: Trade | null } } = {}
+  // for (let exchange in Exchange) {
+  //   if (isNaN(Number(exchange))) {
+  //     const exObj: Exchange = Exchange[exchange as keyof typeof Exchange];
+  //     const num = Number(exchange)
+  //     const tradeIn = useTradeExactIn(
+  //       exObj,
+  //       isExactIn ? parsedAmount : undefined,
+  //       outputCurrency ?? undefined
+  //     )
+  //     const tradeOut = useTradeExactOut(
+  //       exObj,
+  //       inputCurrency ?? undefined,
+  //       !isExactIn ? parsedAmount : undefined
+  //     )
+  //     if (tradeIn) bestTradeExactInEx = { [num]: { trade: tradeIn } }
+  //     if (tradeOut) bestTradeExactOutEx = { [num]: { trade: tradeOut } }
+  //   }
+  // }
+
   const bestTradeExactIn = useTradeExactIn(
     Exchange.UNI,
     isExactIn ? parsedAmount : undefined,
@@ -235,8 +257,8 @@ export function useDerivedSwapInfo(): {
         ? slippageAdjustedAmountsV1[Field.INPUT]
         : null
       : slippageAdjustedAmounts
-      ? slippageAdjustedAmounts[Field.INPUT]
-      : null
+        ? slippageAdjustedAmounts[Field.INPUT]
+        : null
   ]
 
   if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -139,24 +139,24 @@ export function useDerivedSwapInfo(): {
 
   const isExactIn: boolean = independentField === Field.INPUT
   const parsedAmount = tryParseAmount(typedValue, (isExactIn ? inputCurrency : outputCurrency) ?? undefined)
-
-  const bestTradeExactIn = useTradeExactIn(isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined, Exchange.UNI)
-  const bestTradeExactInSushi = useTradeExactIn(isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined, Exchange.SUSHI)
-  const bestTradeExactOut = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined, Exchange.UNI)
-  const bestTradeExactOutSushi = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined, Exchange.SUSHI)
+  const bestTradeExactIn = useTradeExactIn(Exchange.UNI, isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
+  const bestTradeExactInSushi = useTradeExactIn(Exchange.SUSHI, isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
+  const bestTradeExactOut = useTradeExactOut(Exchange.UNI, inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
+  const bestTradeExactOutSushi = useTradeExactOut(Exchange.SUSHI, inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
   //compare quotes
   let v2Trade
   if (isExactIn) {
     //simpler?
     if (bestTradeExactIn && !bestTradeExactInSushi) v2Trade = bestTradeExactIn
     if (!bestTradeExactIn && bestTradeExactInSushi) v2Trade = bestTradeExactInSushi
-    if (bestTradeExactIn && bestTradeExactInSushi) v2Trade = bestTradeExactIn.executionPrice < bestTradeExactInSushi.executionPrice ? bestTradeExactIn : bestTradeExactInSushi
+    if (bestTradeExactIn && bestTradeExactInSushi) v2Trade = bestTradeExactIn.outputAmount.toExact() > bestTradeExactInSushi.outputAmount.toExact() ? bestTradeExactIn : bestTradeExactInSushi
   } else {
     if (bestTradeExactOut && !bestTradeExactOutSushi) v2Trade = bestTradeExactOut
     if (!bestTradeExactOut && bestTradeExactOutSushi) v2Trade = bestTradeExactOutSushi
-    if (bestTradeExactOut && bestTradeExactOutSushi) v2Trade = bestTradeExactOut.executionPrice < bestTradeExactOutSushi.executionPrice ? bestTradeExactOut : bestTradeExactOutSushi
+    if (bestTradeExactOut && bestTradeExactOutSushi) v2Trade = bestTradeExactOut.inputAmount.toExact() < bestTradeExactOutSushi.inputAmount.toExact() ? bestTradeExactOut : bestTradeExactOutSushi
   }
-  //TODO implement sushiswap router after we established what is the better quote here
+  //from here on we already set the right exchange for the trade - just need to set the router contract
+
   const currencyBalances = {
     [Field.INPUT]: relevantTokenBalances[0],
     [Field.OUTPUT]: relevantTokenBalances[1]

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -257,8 +257,8 @@ export function useDerivedSwapInfo(): {
         ? slippageAdjustedAmountsV1[Field.INPUT]
         : null
       : slippageAdjustedAmounts
-        ? slippageAdjustedAmounts[Field.INPUT]
-        : null
+      ? slippageAdjustedAmounts[Field.INPUT]
+      : null
   ]
 
   if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -139,21 +139,45 @@ export function useDerivedSwapInfo(): {
 
   const isExactIn: boolean = independentField === Field.INPUT
   const parsedAmount = tryParseAmount(typedValue, (isExactIn ? inputCurrency : outputCurrency) ?? undefined)
-  const bestTradeExactIn = useTradeExactIn(Exchange.UNI, isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
-  const bestTradeExactInSushi = useTradeExactIn(Exchange.SUSHI, isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
-  const bestTradeExactOut = useTradeExactOut(Exchange.UNI, inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
-  const bestTradeExactOutSushi = useTradeExactOut(Exchange.SUSHI, inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
+  const bestTradeExactIn = useTradeExactIn(
+    Exchange.UNI,
+    isExactIn ? parsedAmount : undefined,
+    outputCurrency ?? undefined
+  )
+  const bestTradeExactInSushi = useTradeExactIn(
+    Exchange.SUSHI,
+    isExactIn ? parsedAmount : undefined,
+    outputCurrency ?? undefined
+  )
+  const bestTradeExactOut = useTradeExactOut(
+    Exchange.UNI,
+    inputCurrency ?? undefined,
+    !isExactIn ? parsedAmount : undefined
+  )
+  const bestTradeExactOutSushi = useTradeExactOut(
+    Exchange.SUSHI,
+    inputCurrency ?? undefined,
+    !isExactIn ? parsedAmount : undefined
+  )
   //compare quotes
   let v2Trade
   if (isExactIn) {
     //simpler?
     if (bestTradeExactIn && !bestTradeExactInSushi) v2Trade = bestTradeExactIn
     if (!bestTradeExactIn && bestTradeExactInSushi) v2Trade = bestTradeExactInSushi
-    if (bestTradeExactIn && bestTradeExactInSushi) v2Trade = bestTradeExactIn.outputAmount.toExact() > bestTradeExactInSushi.outputAmount.toExact() ? bestTradeExactIn : bestTradeExactInSushi
+    if (bestTradeExactIn && bestTradeExactInSushi)
+      v2Trade =
+        bestTradeExactIn.outputAmount.toExact() > bestTradeExactInSushi.outputAmount.toExact()
+          ? bestTradeExactIn
+          : bestTradeExactInSushi
   } else {
     if (bestTradeExactOut && !bestTradeExactOutSushi) v2Trade = bestTradeExactOut
     if (!bestTradeExactOut && bestTradeExactOutSushi) v2Trade = bestTradeExactOutSushi
-    if (bestTradeExactOut && bestTradeExactOutSushi) v2Trade = bestTradeExactOut.inputAmount.toExact() < bestTradeExactOutSushi.inputAmount.toExact() ? bestTradeExactOut : bestTradeExactOutSushi
+    if (bestTradeExactOut && bestTradeExactOutSushi)
+      v2Trade =
+        bestTradeExactOut.inputAmount.toExact() < bestTradeExactOutSushi.inputAmount.toExact()
+          ? bestTradeExactOut
+          : bestTradeExactOutSushi
   }
   //from here on we already set the right exchange for the trade - just need to set the router contract
 
@@ -211,8 +235,8 @@ export function useDerivedSwapInfo(): {
         ? slippageAdjustedAmountsV1[Field.INPUT]
         : null
       : slippageAdjustedAmounts
-        ? slippageAdjustedAmounts[Field.INPUT]
-        : null
+      ? slippageAdjustedAmounts[Field.INPUT]
+      : null
   ]
 
   if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -1,4 +1,4 @@
-import { ChainId, Pair, Token } from '@alchemistcoin/sdk'
+import { ChainId, Exchange, Pair, Token } from '@alchemistcoin/sdk'
 import flatMap from 'lodash.flatmap'
 import { useCallback, useMemo } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
@@ -207,12 +207,22 @@ export function useURLWarningToggle(): () => void {
 }
 
 /**
- * Given two tokens return the liquidity token that represents its liquidity shares
+ * Given two tokens return the liquidity token that represents its liquidity shares (for Uniswap)
  * @param tokenA one of the two tokens
  * @param tokenB the other token
  */
 export function toV2LiquidityToken([tokenA, tokenB]: [Token, Token]): Token {
-  return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB), 18, 'UNI-V2', 'Uniswap V2')
+  return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB, Exchange.UNI), 18, 'UNI-V2', 'Uniswap V2')
+}
+
+/**
+ * Given two tokens return the liquidity token that represents its liquidity shares
+ * @param tokenA one of the two tokens
+ * @param tokenB the other token
+ * @param exchange the dex
+ */
+ export function toV2LiquidityTokenGeneral([tokenA, tokenB]: [Token, Token], exchange : Exchange): Token {
+  return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB, exchange), 18, 'UNI-V2', 'Uniswap V2')
 }
 
 /**

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -221,7 +221,7 @@ export function toV2LiquidityToken([tokenA, tokenB]: [Token, Token]): Token {
  * @param tokenB the other token
  * @param exchange the dex
  */
- export function toV2LiquidityTokenGeneral([tokenA, tokenB]: [Token, Token], exchange : Exchange): Token {
+export function toV2LiquidityTokenGeneral([tokenA, tokenB]: [Token, Token], exchange: Exchange): Token {
   return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB, exchange), 18, 'UNI-V2', 'Uniswap V2')
 }
 

--- a/src/utils/prices.test.ts
+++ b/src/utils/prices.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, JSBI, Pair, Route, Token, TokenAmount, Trade, TradeType } from '@alchemistcoin/sdk'
+import { ChainId, Exchange, JSBI, Pair, Route, Token, TokenAmount, Trade, TradeType } from '@alchemistcoin/sdk'
 import { computeTradePriceBreakdown } from './prices'
 
 describe('prices', () => {
@@ -6,8 +6,10 @@ describe('prices', () => {
   const token2 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000002', 18)
   const token3 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000003', 18)
 
-  const pair12 = new Pair(new TokenAmount(token1, JSBI.BigInt(10000)), new TokenAmount(token2, JSBI.BigInt(20000)))
-  const pair23 = new Pair(new TokenAmount(token2, JSBI.BigInt(20000)), new TokenAmount(token3, JSBI.BigInt(30000)))
+  const exchange = Exchange.UNI
+
+  const pair12 = new Pair(new TokenAmount(token1, JSBI.BigInt(10000)), new TokenAmount(token2, JSBI.BigInt(20000)), exchange)
+  const pair23 = new Pair(new TokenAmount(token2, JSBI.BigInt(20000)), new TokenAmount(token3, JSBI.BigInt(30000)), exchange)
 
   describe('computeTradePriceBreakdown', () => {
     it('returns undefined for undefined', () => {
@@ -20,7 +22,7 @@ describe('prices', () => {
     it('correct realized lp fee for single hop', () => {
       expect(
         computeTradePriceBreakdown(
-          new Trade(new Route([pair12], token1), new TokenAmount(token1, JSBI.BigInt(1000)), TradeType.EXACT_INPUT)
+          new Trade(new Route([pair12], token1), new TokenAmount(token1, JSBI.BigInt(1000)), TradeType.EXACT_INPUT, exchange)
         ).realizedLPFee
       ).toEqual(new TokenAmount(token1, JSBI.BigInt(3)))
     })
@@ -31,7 +33,7 @@ describe('prices', () => {
           new Trade(
             new Route([pair12, pair23], token1),
             new TokenAmount(token1, JSBI.BigInt(1000)),
-            TradeType.EXACT_INPUT
+            TradeType.EXACT_INPUT, exchange
           )
         ).realizedLPFee
       ).toEqual(new TokenAmount(token1, JSBI.BigInt(5)))

--- a/src/utils/prices.test.ts
+++ b/src/utils/prices.test.ts
@@ -8,8 +8,16 @@ describe('prices', () => {
 
   const exchange = Exchange.UNI
 
-  const pair12 = new Pair(new TokenAmount(token1, JSBI.BigInt(10000)), new TokenAmount(token2, JSBI.BigInt(20000)), exchange)
-  const pair23 = new Pair(new TokenAmount(token2, JSBI.BigInt(20000)), new TokenAmount(token3, JSBI.BigInt(30000)), exchange)
+  const pair12 = new Pair(
+    new TokenAmount(token1, JSBI.BigInt(10000)),
+    new TokenAmount(token2, JSBI.BigInt(20000)),
+    exchange
+  )
+  const pair23 = new Pair(
+    new TokenAmount(token2, JSBI.BigInt(20000)),
+    new TokenAmount(token3, JSBI.BigInt(30000)),
+    exchange
+  )
 
   describe('computeTradePriceBreakdown', () => {
     it('returns undefined for undefined', () => {
@@ -22,7 +30,12 @@ describe('prices', () => {
     it('correct realized lp fee for single hop', () => {
       expect(
         computeTradePriceBreakdown(
-          new Trade(new Route([pair12], token1), new TokenAmount(token1, JSBI.BigInt(1000)), TradeType.EXACT_INPUT, exchange)
+          new Trade(
+            new Route([pair12], token1),
+            new TokenAmount(token1, JSBI.BigInt(1000)),
+            TradeType.EXACT_INPUT,
+            exchange
+          )
         ).realizedLPFee
       ).toEqual(new TokenAmount(token1, JSBI.BigInt(3)))
     })
@@ -33,7 +46,8 @@ describe('prices', () => {
           new Trade(
             new Route([pair12, pair23], token1),
             new TokenAmount(token1, JSBI.BigInt(1000)),
-            TradeType.EXACT_INPUT, exchange
+            TradeType.EXACT_INPUT,
+            exchange
           )
         ).realizedLPFee
       ).toEqual(new TokenAmount(token1, JSBI.BigInt(5)))

--- a/src/utils/useUSDCPrice.ts
+++ b/src/utils/useUSDCPrice.ts
@@ -1,4 +1,4 @@
-import { ChainId, Currency, currencyEquals, JSBI, Price, WETH } from '@alchemistcoin/sdk'
+import { ChainId, Currency, currencyEquals, Exchange, JSBI, Price, WETH } from '@alchemistcoin/sdk'
 import { useMemo } from 'react'
 import { USDC } from '../constants'
 import { PairState, usePairs } from '../data/Reserves'
@@ -6,7 +6,7 @@ import { useActiveWeb3React } from '../hooks'
 import { wrappedCurrency } from './wrappedCurrency'
 
 /**
- * Returns the price in USDC of the input currency
+ * Returns the price in USDC of the input currency (from Uniswap)
  * @param currency currency to compute the USDC price of
  */
 export default function useUSDCPrice(currency?: Currency): Price | undefined {
@@ -23,7 +23,7 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
     ],
     [chainId, currency, wrapped]
   )
-  const [[ethPairState, ethPair], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = usePairs(tokenPairs)
+  const [[ethPairState, ethPair], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = usePairs(tokenPairs, Exchange.UNI)
 
   return useMemo(() => {
     if (!currency || !wrapped || !chainId) {

--- a/src/utils/useUSDCPrice.ts
+++ b/src/utils/useUSDCPrice.ts
@@ -23,7 +23,10 @@ export default function useUSDCPrice(currency?: Currency): Price | undefined {
     ],
     [chainId, currency, wrapped]
   )
-  const [[ethPairState, ethPair], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = usePairs(tokenPairs, Exchange.UNI)
+  const [[ethPairState, ethPair], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = usePairs(
+    tokenPairs,
+    Exchange.UNI
+  )
 
   return useMemo(() => {
     if (!currency || !wrapped || !chainId) {

--- a/src/utils/v1SwapArgument.test.ts
+++ b/src/utils/v1SwapArgument.test.ts
@@ -1,4 +1,4 @@
-import { CurrencyAmount, ETHER, Percent, Route, TokenAmount, Trade } from '@alchemistcoin/sdk'
+import { CurrencyAmount, ETHER, Exchange, Percent, Route, TokenAmount, Trade } from '@alchemistcoin/sdk'
 import { DAI, USDC } from '../constants'
 import { MockV1Pair } from '../data/V1'
 import v1SwapArguments from './v1SwapArguments'
@@ -7,11 +7,13 @@ describe('v1SwapArguments', () => {
   const USDC_WETH = new MockV1Pair('1000000', new TokenAmount(USDC, '1000000'))
   const DAI_WETH = new MockV1Pair('1000000', new TokenAmount(DAI, '1000000'))
 
+  const exchange = Exchange.UNI
+
   // just some random address
   const TEST_RECIPIENT_ADDRESS = USDC_WETH.liquidityToken.address
 
   it('exact eth to token', () => {
-    const trade = Trade.exactIn(new Route([USDC_WETH], ETHER), CurrencyAmount.ether('100'))
+    const trade = Trade.exactIn(new Route([USDC_WETH], ETHER), CurrencyAmount.ether('100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),
@@ -22,7 +24,7 @@ describe('v1SwapArguments', () => {
     expect(result.value).toEqual('0x64')
   })
   it('exact token to eth', () => {
-    const trade = Trade.exactIn(new Route([USDC_WETH], USDC, ETHER), new TokenAmount(USDC, '100'))
+    const trade = Trade.exactIn(new Route([USDC_WETH], USDC, ETHER), new TokenAmount(USDC, '100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),
@@ -36,7 +38,7 @@ describe('v1SwapArguments', () => {
     expect(result.value).toEqual('0x0')
   })
   it('exact token to token', () => {
-    const trade = Trade.exactIn(new Route([USDC_WETH, DAI_WETH], USDC), new TokenAmount(USDC, '100'))
+    const trade = Trade.exactIn(new Route([USDC_WETH, DAI_WETH], USDC), new TokenAmount(USDC, '100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),
@@ -52,7 +54,7 @@ describe('v1SwapArguments', () => {
     expect(result.value).toEqual('0x0')
   })
   it('eth to exact token', () => {
-    const trade = Trade.exactOut(new Route([USDC_WETH], ETHER), new TokenAmount(USDC, '100'))
+    const trade = Trade.exactOut(new Route([USDC_WETH], ETHER), new TokenAmount(USDC, '100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),
@@ -65,7 +67,7 @@ describe('v1SwapArguments', () => {
     expect(result.value).toEqual('0x66')
   })
   it('token to exact eth', () => {
-    const trade = Trade.exactOut(new Route([USDC_WETH], USDC, ETHER), CurrencyAmount.ether('100'))
+    const trade = Trade.exactOut(new Route([USDC_WETH], USDC, ETHER), CurrencyAmount.ether('100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),
@@ -79,7 +81,7 @@ describe('v1SwapArguments', () => {
     expect(result.value).toEqual('0x0')
   })
   it('token to exact token', () => {
-    const trade = Trade.exactOut(new Route([USDC_WETH, DAI_WETH], USDC), new TokenAmount(DAI, '100'))
+    const trade = Trade.exactOut(new Route([USDC_WETH, DAI_WETH], USDC), new TokenAmount(DAI, '100'), exchange)
     const result = v1SwapArguments(trade, {
       recipient: TEST_RECIPIENT_ADDRESS,
       allowedSlippage: new Percent('1', '100'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,11 +4,11 @@
 
 "@alchemistcoin/default-token-list@git+https://github.com/alchemistcoin/default-token-list.git#main":
   version "1.0.0"
-  resolved "git+https://github.com/alchemistcoin/default-token-list.git#464bd3bc08089c95a73a37e907870e416cdffe07"
+  resolved "git+https://github.com/alchemistcoin/default-token-list.git#e67243f7f38947dde895cf47776190395c2b68f9"
 
 "@alchemistcoin/sdk@git+https://github.com/alchemistcoin/alchemist-sdk.git#dev":
   version "3.0.3"
-  resolved "git+https://github.com/alchemistcoin/alchemist-sdk.git#50e0413f9aa6cb12819034364f8fa525b0381179"
+  resolved "git+https://github.com/alchemistcoin/alchemist-sdk.git#68df24f7fdd3dce427ac4a7c57505f4e4d6daa1f"
   dependencies:
     "@uniswap/v2-core" "^1.0.0"
     big.js "^5.2.2"
@@ -81,11 +81,11 @@
     source-map "^0.5.0"
 
 "@babel/generator@^7.14.0", "@babel/generator@^7.4.0", "@babel/generator@^7.9.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.0.tgz#0f35d663506c43e4f10898fbda0d752ec75494be"
-  integrity sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.1.tgz#1f99331babd65700183628da186f36f63d615c93"
+  integrity sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==
   dependencies:
-    "@babel/types" "^7.14.0"
+    "@babel/types" "^7.14.1"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -115,9 +115,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.14.0", "@babel/helper-create-class-features-plugin@^7.8.3":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.0.tgz#38367d3dab125b12f94273de418f4df23a11a15e"
-  integrity sha512-6pXDPguA5zC40Y8oI5mqr+jEUpjMJonKvknvA+vD8CYDz5uuXEwWBK8sRAsE/t3gfb1k15AQb9RhwpscC4nUJQ==
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.1.tgz#1fe11b376f3c41650ad9fedc665b0068722ea76c"
+  integrity sha512-r8rsUahG4ywm0QpGcCrLaUSOuNAISR3IZCg4Fx05Ozq31aCUrQsTLH6KPxy0N5ULoQ4Sn9qjNdGNtbPWAC6hYg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
     "@babel/helper-function-name" "^7.12.13"
@@ -298,9 +298,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.0", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.0.tgz#2f0ebfed92bcddcc8395b91f1895191ce2760380"
-  integrity sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.1.tgz#1bd644b5db3f5797c4479d89ec1817fe02b84c47"
+  integrity sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -628,10 +628,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-block-scoping@^7.13.16", "@babel/plugin-transform-block-scoping@^7.8.3":
-  version "7.13.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.13.16.tgz#a9c0f10794855c63b1d629914c7dcfeddd185892"
-  integrity sha512-ad3PHUxGnfWF4Efd3qFuznEtZKoBp0spS+DgqzVzRPV7urEBvPLue3y2j80w4Jf2YLzZHj8TOv/Lmvdmh3b2xg==
+"@babel/plugin-transform-block-scoping@^7.14.1", "@babel/plugin-transform-block-scoping@^7.8.3":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.1.tgz#ac1b3a8e3d8cbb31efc6b9be2f74eb9823b74ab2"
+  integrity sha512-2mQXd0zBrwfp0O1moWIhPpEeTKDvxyHcnma3JATVP1l+CctWBuot6OJG8LQ4DnBj4ZZPSmlb/fm4mu47EOAnVA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.13.0"
 
@@ -1020,9 +1020,9 @@
     semver "^5.5.0"
 
 "@babel/preset-env@^7.4.5":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.0.tgz#236f88cd5da625e625dd40500d4824523f50e6c5"
-  integrity sha512-GWRCdBv2whxqqaSi7bo/BEXf070G/fWFMEdCnmoRg2CZJy4GK06ovFuEjJrZhDRXYgBsYtxVbG8GUHvw+UWBkQ==
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.1.tgz#b55914e2e68885ea03f69600b2d3537e54574a93"
+  integrity sha512-0M4yL1l7V4l+j/UHvxcdvNfLB9pPtIooHTbEhgD/6UGyh8Hy3Bm1Mj0buzjDXATCSz3JFibVdnoJZCrlUCanrQ==
   dependencies:
     "@babel/compat-data" "^7.14.0"
     "@babel/helper-compilation-targets" "^7.13.16"
@@ -1061,7 +1061,7 @@
     "@babel/plugin-transform-arrow-functions" "^7.13.0"
     "@babel/plugin-transform-async-to-generator" "^7.13.0"
     "@babel/plugin-transform-block-scoped-functions" "^7.12.13"
-    "@babel/plugin-transform-block-scoping" "^7.13.16"
+    "@babel/plugin-transform-block-scoping" "^7.14.1"
     "@babel/plugin-transform-classes" "^7.13.0"
     "@babel/plugin-transform-computed-properties" "^7.13.0"
     "@babel/plugin-transform-destructuring" "^7.13.17"
@@ -1091,7 +1091,7 @@
     "@babel/plugin-transform-unicode-escapes" "^7.12.13"
     "@babel/plugin-transform-unicode-regex" "^7.12.13"
     "@babel/preset-modules" "^0.1.4"
-    "@babel/types" "^7.14.0"
+    "@babel/types" "^7.14.1"
     babel-plugin-polyfill-corejs2 "^0.2.0"
     babel-plugin-polyfill-corejs3 "^0.2.0"
     babel-plugin-polyfill-regenerator "^0.2.0"
@@ -1193,10 +1193,10 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.0.tgz#3fc3fc74e0cdad878182e5f66cc6bcab1915a802"
-  integrity sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.0", "@babel/types@^7.14.1", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.1.tgz#095bd12f1c08ab63eff6e8f7745fa7c9cc15a9db"
+  integrity sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
@@ -2030,9 +2030,9 @@
     regenerator-runtime "^0.13.3"
 
 "@json-rpc-tools/types@^1.6.1":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@json-rpc-tools/types/-/types-1.7.2.tgz#1925e2c8071233beee99f8b4a12a09255489567a"
-  integrity sha512-PrR9NqzGTG0gWRUARa1SbPaQb1SNXv4dJMLp8lEmTNXWtEGS032m3qaWPwyhaqr6/ocpNxsrPra7KtKFzQgIoA==
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/types/-/types-1.7.3.tgz#ee7185314ecb815bfd486bbc15a86ab2f5b86680"
+  integrity sha512-wCv2e3bRNI309J5ATch0sPo3SKYoXDqyygsWtIUXOnv2pb0gzZVfj0lDbXVvdIDch2EUKPjY/8KyCA+lhFn7Jw==
   dependencies:
     keyvaluestorage-interface "^1.0.0"
 
@@ -2066,6 +2066,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@pedrouid/environment@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pedrouid/environment/-/environment-1.0.1.tgz#858f0f8a057340e0b250398b75ead77d6f4342ec"
+  integrity sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==
+
 "@pedrouid/iso-crypto@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@pedrouid/iso-crypto/-/iso-crypto-1.1.0.tgz#3fb4050ea99f2f8ee41ba8661193c0989c815c95"
@@ -2077,10 +2082,11 @@
     hash.js "^1.1.7"
 
 "@pedrouid/iso-random@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@pedrouid/iso-random/-/iso-random-1.1.0.tgz#4b9561670fcb31a45e8520852f1bfac34316b111"
-  integrity sha512-U8P2qdbvyU5aom0036dkpp0C9c8pgW1SNhAo8+zPDzgmKA58Hl6dc+ZkQXkE9aHrzN6v/0w+409JMjSYwx5tVw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@pedrouid/iso-random/-/iso-random-1.2.1.tgz#55178d9a2e7897b0f630dd1b4be76bc8460242d7"
+  integrity sha512-C35NqYMmLsg61WDiEup4OwjRhgfZIcK4BL+Qg49xowHUJ+f7/LFZCO+TGuQqoXFAj1beKIOpUN33f0fqV7zneQ==
   dependencies:
+    "@pedrouid/environment" "^1.0.1"
     enc-utils "^3.0.0"
     randombytes "^2.1.0"
 
@@ -4709,14 +4715,14 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.5, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
-  version "4.16.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.5.tgz#952825440bca8913c62d0021334cbe928ef062ae"
-  integrity sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
   dependencies:
-    caniuse-lite "^1.0.30001214"
+    caniuse-lite "^1.0.30001219"
     colorette "^1.2.2"
-    electron-to-chromium "^1.3.719"
+    electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
@@ -4958,10 +4964,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001214:
-  version "1.0.30001219"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz#5bfa5d0519f41f993618bd318f606a4c4c16156b"
-  integrity sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
+  version "1.0.30001221"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001221.tgz#b916721ddf59066cfbe96c5c9a77cf7ae5c52e65"
+  integrity sha512-b9TOZfND3uGSLjMOrLh8XxSQ41x8mX+9MLJYDM4AAHLfaZHttrLNPrScWjVnBITRZbY5sPpCt7X85n7VSLZ+/g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5541,17 +5547,17 @@ copy-to-clipboard@^3.2.0:
     toggle-selection "^1.0.6"
 
 core-js-compat@^3.6.2, core-js-compat@^3.9.0, core-js-compat@^3.9.1:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.11.1.tgz#57a91e9b02d3bb8cf37f82eceaf44a3d646fa614"
-  integrity sha512-aZ0e4tmlG/aOBHj92/TuOuZwp6jFvn1WNabU5VOVixzhu5t5Ao+JZkQOPlgNXu6ynwLrwJxklT4Gw1G1VGEh+g==
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.11.2.tgz#5048e367851cfd2c6c0cb81310757b4da296e385"
+  integrity sha512-gYhNwu7AJjecNtRrIfyoBabQ3ZG+llfPmg9BifIX8yxIpDyfNLRM73zIjINSm6z3dMdI1nwNC9C7uiy4pIC6cw==
   dependencies:
-    browserslist "^4.16.5"
+    browserslist "^4.16.6"
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.11.1.tgz#fd52fa8c8b7b797b3606524b3d97278a8d8e7f09"
-  integrity sha512-2JukQi8HgAOCD5CSimxWWXVrUBoA9Br796uIA5Z06bIjt7PBBI19ircFaAxplgE1mJf3x2BY6MkT/HWA/UryPg==
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.11.2.tgz#10e3b35788c00f431bc0d601d7551475ec3e792c"
+  integrity sha512-DQxdEKm+zFsnON7ZGOgUAQXBt1UJJ01tOzN/HgQ7cNf0oEHW1tcBLfCQQd1q6otdLu5gAdvKYxKHAoXGwE/kiQ==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
@@ -5559,9 +5565,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.5.0:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.1.tgz#f920392bf8ed63a0ec8e4e729857bfa3d121c525"
-  integrity sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ==
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.2.tgz#af087a43373fc6e72942917c4a4c3de43ed574d6"
+  integrity sha512-3tfrrO1JpJSYGKnd9LKTBPqgUES/UYiCzMKeqwR1+jF16q4kD1BY2NvqkfuzXwQ6+CIWm55V9cjD7PQd+hijdw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6433,10 +6439,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.719:
-  version "1.3.723"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.723.tgz#52769a75635342a4db29af5f1e40bd3dad02c877"
-  integrity sha512-L+WXyXI7c7+G1V8ANzRsPI5giiimLAUDC6Zs1ojHHPhYXb3k/iTABFmWjivEtsWrRQymjnO66/rO2ZTABGdmWg==
+electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.723:
+  version "1.3.726"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.726.tgz#6d3c577e5f5a48904ba891464740896c05e3bdb1"
+  integrity sha512-dw7WmrSu/JwtACiBzth8cuKf62NKL1xVJuNvyOg0jvruN/n4NLtGYoTzciQquCPNaS2eR+BT5GrxHbslfc/w1w==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Adds the possibility to support multiple dex with sushiswap integrated rn
When the user puts an amount into the interface we compare sushi vs uni and display the better quote. After that we call our router contract with the corresponding router address.