### PR TITLE
ALC 455 - Separate pending from completed transactions

### DIFF
--- a/src/components/AccountDetails/Transaction.tsx
+++ b/src/components/AccountDetails/Transaction.tsx
@@ -22,7 +22,7 @@ const TransactionWrapper = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;
-  margin-bottom: .125rem;
+  margin-bottom: 0.125rem;
 `
 
 const TransactionStatusText = styled.div`
@@ -103,10 +103,7 @@ export default function Transaction({ hash }: { hash: string }) {
     <RowFixed flex="1">
       <TransactionStatusText>
         {summary ?? truncateStringMiddle(hash, 6, 7)}
-        {success
-          ? '&nbsp;↗'
-          : ''
-        }
+        {success ? '&nbsp;↗' : ''}
       </TransactionStatusText>
     </RowFixed>
   )
@@ -130,18 +127,13 @@ export default function Transaction({ hash }: { hash: string }) {
 
   return (
     <TransactionWrapper>
-      {success
-        ? (
-          <TransactionState
-            href={getEtherscanLink(chainId, hash, 'transaction')}
-            pending={pending}
-            success={success}
-          >
-            {Row}
-          </TransactionState>
-        )
-        : Row
-      }
+      {success ? (
+        <TransactionState href={getEtherscanLink(chainId, hash, 'transaction')} pending={pending} success={success}>
+          {Row}
+        </TransactionState>
+      ) : (
+        Row
+      )}
       {canCancel && (
         <CancelButton disabled={tx?.cancel === Status.CANCEL_TRANSACTION_PENDING} onClick={handleCancelClick}>
           {t('Cancel')}

--- a/src/components/AccountDetails/Transaction.tsx
+++ b/src/components/AccountDetails/Transaction.tsx
@@ -19,36 +19,35 @@ import { useTranslation } from 'react-i18next'
 import { darken } from 'polished'
 
 const TransactionWrapper = styled.div`
-  display: flex;
   align-items: center;
+  display: flex;
   justify-content: space-between;
+  margin-bottom: .125rem;
 `
 
 const TransactionStatusText = styled.div`
-  margin-right: 0.5rem;
-  display: flex;
   align-items: center;
+  color: ${({ theme }) => theme.text3};
+  display: flex;
+  font-weight: 500;
+  font-size: 0.825rem;
+  margin-right: 0.5rem;
+`
+
+const TransactionState = styled(ExternalLink)<{ pending: boolean; success?: boolean }>`
+  border-radius: 0.5rem;
+  padding: 0.25rem 0rem;
+  text-decoration: none !important;
+  flex: 1;
+
   :hover {
+    color: ${({ theme }) => theme.text1};
     text-decoration: underline;
   }
 `
 
-const TransactionState = styled(ExternalLink)<{ pending: boolean; success?: boolean }>`
-  text-decoration: none !important;
-  border-radius: 0.5rem;
-  padding: 0.25rem 0rem;
-  flex: 1;
-  font-weight: 500;
-  font-size: 0.825rem;
-  color: ${({ theme }) => theme.text3};
-
-  :hover {
-    color: ${({ theme }) => theme.text1};
-  }
-`
-
 const StatusText = styled.div<{ cancelled?: boolean }>`
-  color: ${({ theme }) => theme.primary2}
+  color: ${({ theme }) => theme.text2}
   font-size: .75rem;
   font-weight: 600;
   margin: 0 .5rem;
@@ -100,6 +99,18 @@ export default function Transaction({ hash }: { hash: string }) {
   const success = tx && isSuccessfulTransaction(tx)
   const cancelTransaction = useTransactionCanceller()
 
+  const Row = (
+    <RowFixed flex="1">
+      <TransactionStatusText>
+        {summary ?? truncateStringMiddle(hash, 6, 7)}
+        {success
+          ? '&nbsp;↗'
+          : ''
+        }
+      </TransactionStatusText>
+    </RowFixed>
+  )
+
   function handleCancelClick() {
     if (!chainId) return
     if (!tx?.processed) return
@@ -119,11 +130,18 @@ export default function Transaction({ hash }: { hash: string }) {
 
   return (
     <TransactionWrapper>
-      <TransactionState href={getEtherscanLink(chainId, hash, 'transaction')} pending={pending} success={success}>
-        <RowFixed>
-          <TransactionStatusText>{summary ?? truncateStringMiddle(hash, 6, 7)} ↗</TransactionStatusText>
-        </RowFixed>
-      </TransactionState>
+      {success
+        ? (
+          <TransactionState
+            href={getEtherscanLink(chainId, hash, 'transaction')}
+            pending={pending}
+            success={success}
+          >
+            {Row}
+          </TransactionState>
+        )
+        : Row
+      }
       {canCancel && (
         <CancelButton disabled={tx?.cancel === Status.CANCEL_TRANSACTION_PENDING} onClick={handleCancelClick}>
           {t('Cancel')}

--- a/src/components/AccountDetails/Transaction.tsx
+++ b/src/components/AccountDetails/Transaction.tsx
@@ -22,7 +22,7 @@ const TransactionWrapper = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;
-  padding: .25rem 0;
+  padding: 0.25rem 0;
 `
 
 const TransactionStatusText = styled.div`

--- a/src/components/AccountDetails/Transaction.tsx
+++ b/src/components/AccountDetails/Transaction.tsx
@@ -22,7 +22,7 @@ const TransactionWrapper = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.125rem;
+  padding: .25rem 0;
 `
 
 const TransactionStatusText = styled.div`
@@ -36,11 +36,10 @@ const TransactionStatusText = styled.div`
 
 const TransactionState = styled(ExternalLink)<{ pending: boolean; success?: boolean }>`
   border-radius: 0.5rem;
-  padding: 0.25rem 0rem;
   text-decoration: none !important;
   flex: 1;
 
-  :hover {
+  :hover .transaction-status-text {
     color: ${({ theme }) => theme.text1};
     text-decoration: underline;
   }
@@ -101,9 +100,9 @@ export default function Transaction({ hash }: { hash: string }) {
 
   const Row = (
     <RowFixed flex="1">
-      <TransactionStatusText>
+      <TransactionStatusText className="transaction-status-text">
         {summary ?? truncateStringMiddle(hash, 6, 7)}
-        {success ? '&nbsp;↗' : ''}
+        {success ? ' ↗' : ''}
       </TransactionStatusText>
     </RowFixed>
   )

--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -199,12 +199,27 @@ const MainWalletAction = styled(WalletAction)`
   color: ${({ theme }) => theme.primary1};
 `
 
+const EmptyResults = styled.div`
+  color: ${({ theme }) => theme.text3};
+  font-size: .825rem;
+  font-weight: 500;
+`
+
 function renderTransactions(transactions: string[]) {
   return (
     <TransactionListWrapper>
-      {transactions.map((hash, i) => {
-        return <Transaction key={i} hash={hash} />
-      })}
+      {!!transactions.length
+        ? (
+          transactions.map((hash, i) => {
+            return <Transaction key={i} hash={hash} />
+          })
+        )
+        : (
+          <EmptyResults>
+            Nothing here yet
+          </EmptyResults>
+        )
+      }
     </TransactionListWrapper>
   )
 }
@@ -394,10 +409,13 @@ export default function AccountDetails({
       {!!pendingTransactions.length || !!confirmedTransactions.length ? (
         <LowerSection>
           <AutoRow mb={'1rem'} style={{ justifyContent: 'space-between' }}>
-            <TYPE.body>Recent Transactions</TYPE.body>
-            <LinkStyledButton onClick={clearAllTransactionsCallback}>(clear completed)</LinkStyledButton>
+            <TYPE.body>Pending Transactions</TYPE.body>
           </AutoRow>
           {renderTransactions(pendingTransactions)}
+          <AutoRow mb={'1rem'} mt={'2rem'} style={{ justifyContent: 'space-between' }}>
+            <TYPE.body>Recent Transactions</TYPE.body>
+            <LinkStyledButton onClick={clearAllTransactionsCallback}>(clear all)</LinkStyledButton>
+          </AutoRow>
           {renderTransactions(confirmedTransactions)}
         </LowerSection>
       ) : (

--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -201,25 +201,20 @@ const MainWalletAction = styled(WalletAction)`
 
 const EmptyResults = styled.div`
   color: ${({ theme }) => theme.text3};
-  font-size: .825rem;
+  font-size: 0.825rem;
   font-weight: 500;
 `
 
 function renderTransactions(transactions: string[]) {
   return (
     <TransactionListWrapper>
-      {!!transactions.length
-        ? (
-          transactions.map((hash, i) => {
-            return <Transaction key={i} hash={hash} />
-          })
-        )
-        : (
-          <EmptyResults>
-            Nothing here yet
-          </EmptyResults>
-        )
-      }
+      {!!transactions.length ? (
+        transactions.map((hash, i) => {
+          return <Transaction key={i} hash={hash} />
+        })
+      ) : (
+        <EmptyResults>Nothing here yet</EmptyResults>
+      )}
     </TransactionListWrapper>
   )
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -214,13 +214,13 @@ export const ButtonOutlined = styled(Base)`
   color: ${({ theme }) => theme.text1};
 
   &:focus {
-    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.primary2};
   }
   &:hover {
-    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.primary2};
   }
   &:active {
-    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.primary2};
   }
   &:disabled {
     opacity: 50%;

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -150,7 +150,7 @@ function Web3StatusInner() {
   const hasSocks = useHasSocks()
   const toggleWalletModal = useWalletModalToggle()
 
-  console.log('pending transactions', sortedRecentTransactions)
+  console.log('pending transactions', pending)
 
   if (account) {
     return (
@@ -200,8 +200,8 @@ export default function Web3Status() {
     return txs.filter(isTransactionRecent).sort(newTransactionsFirst)
   }, [allTransactions])
 
-  const pending = sortedRecentTransactions.filter(tx => !tx.receipt).map(tx => tx.hash)
-  const confirmed = sortedRecentTransactions.filter(tx => tx.receipt).map(tx => tx.hash)
+  const pending = sortedRecentTransactions.filter(tx => isPendingTransaction(tx)).map(tx => tx.hash)
+  const confirmed = sortedRecentTransactions.filter(tx => !pending.includes(tx.hash)).map(tx => tx.hash)
 
   if (!contextNetwork.active && !active) {
     return null

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -222,11 +222,7 @@ export function usePendingTransactions(): { [txHash: string]: TransactionDetails
 }
 
 export function isPendingTransaction(tx: TransactionDetails): boolean {
-  return !!(
-    tx.status !== Status.FAILED_TRANSACTION &&
-    tx.status !== Status.SUCCESSFUL_TRANSACTION &&
-    !tx.receipt
-  )
+  return !!(tx.status !== Status.FAILED_TRANSACTION && tx.status !== Status.SUCCESSFUL_TRANSACTION && !tx.receipt)
 }
 
 export function useHasPendingTransactions(): boolean {

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -225,9 +225,7 @@ export function isPendingTransaction(tx: TransactionDetails): boolean {
   return !!(
     tx.status !== Status.FAILED_TRANSACTION &&
     tx.status !== Status.SUCCESSFUL_TRANSACTION &&
-    (!tx.receipt && (
-      tx.cancel === Status.CANCEL_TRANSACTION_PENDING || tx.status === Status.PENDING_TRANSACTION
-    ))
+    !tx.receipt
   )
 }
 

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -225,9 +225,9 @@ export function isPendingTransaction(tx: TransactionDetails): boolean {
   return !!(
     tx.status !== Status.FAILED_TRANSACTION &&
     tx.status !== Status.SUCCESSFUL_TRANSACTION &&
-    ((!tx.status && !tx.receipt) ||
-      tx.cancel === Status.CANCEL_TRANSACTION_PENDING ||
-      (tx.status === Status.PENDING_TRANSACTION && (!tx.receipt || tx.receipt.status !== 1)))
+    (!tx.receipt && (
+      tx.cancel === Status.CANCEL_TRANSACTION_PENDING || tx.status === Status.PENDING_TRANSACTION
+    ))
   )
 }
 


### PR DESCRIPTION
* Only allow linking to etherscan if it is a successful transaction

* Minor css styling fixes

* separated pending transactions from completed (successful or failed) in wallet modal