### PR TITLE
FE updates for no double transaction processing on the BE

### DIFF
--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -172,7 +172,8 @@ export function useSwapCallback(
                       bribe: args[2], // need to use calculated bribe
                       routerAddress: ROUTER[trade.exchange],
                       estimatedEffectiveGasPrice: estimatedEffectiveGasPrice,
-                      estimatedGas: Number(trade.estimatedGas)
+                      estimatedGas: Number(trade.estimatedGas),
+                      from: account
                     }
 
                     console.log('emit transaction', transactionReq)

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -151,7 +151,7 @@ export function useTransactionCanceller() {
         status?: string
       }
     ) => {
-      if (!account) return;
+      if (!account) return
 
       emitTransactionCancellation({
         chainId: transaction.chainId,

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -137,6 +137,7 @@ export function useTransactionUpdater(): (
 }
 
 export function useTransactionCanceller() {
+  const { account } = useActiveWeb3React()
   return useCallback(
     async (
       response: TransactionResponseIdentifier,
@@ -150,6 +151,8 @@ export function useTransactionCanceller() {
         status?: string
       }
     ) => {
+      if (!account) return;
+
       emitTransactionCancellation({
         chainId: transaction.chainId,
         serializedSwap: transaction.serializedSwap,
@@ -158,10 +161,11 @@ export function useTransactionCanceller() {
         bribe: transaction.bribe,
         routerAddress: transaction.routerAddress,
         estimatedEffectiveGasPrice: transaction.estimatedEffectiveGasPrice,
-        estimatedGas: transaction.estimatedGas
+        estimatedGas: transaction.estimatedGas,
+        from: account
       })
     },
-    []
+    [account]
   )
 }
 

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -60,6 +60,7 @@ export interface TransactionReq {
   routerAddress: string
   estimatedEffectiveGasPrice?: number
   estimatedGas?: number
+  from: string
 }
 
 export interface TransactionRes {
@@ -80,6 +81,7 @@ export interface TransactionProcessed {
   sessionToken: string
   chainId: number
   simulateOnly: boolean
+  from: string
 }
 
 export interface TransactionDiagnosisRes {


### PR DESCRIPTION
FE update to send from account address to the Transaction Request. Expect transaction failure if a transaction is sent from same address while another is still processing.

* add 'from' to TransactionReq