### PR TITLE
Custom slippage fix

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -199,7 +199,7 @@ export default function SettingsTab() {
             </AutoColumn>
           </ModalContentWrapper>
         </Modal>
-        <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
+        <StyledMenuButton onClick={() => !open && toggle()} id="open-settings-dialog-button">
           <StyledMenuIcon>{open ? <Close /> : <Cog />}</StyledMenuIcon>
           {expertMode ? (
             <EmojiWrapper>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -217,7 +217,7 @@ export default function SettingsTab() {
               <StyledRowFixed>
                 <SettingsHeader>
                   <Text fontWeight={600} fontSize={20}>
-                    Transaction Fee (ETH)
+                    Transaction Fee
                   </Text>
                   <QuestionHelper text="A tip for the miner to accept the transaction. Higher tips are more likely to be accepted." />
                 </SettingsHeader>

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -65,11 +65,13 @@ const Input = styled.input`
 `
 
 const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }>`
-  height: 2rem;
-  position: relative;
-  padding: 0 0.75rem;
+  border: ${({ theme, active, warning }) => (active ? `1px solid ${warning ? theme.red1 : '#35404E'}` : '#35404E')};
+  background-color: #35404e;
   flex: 1;
-  border: ${({ theme, active, warning }) => active && `1px solid ${warning ? theme.red1 : theme.primary2}`};
+  font-weight: 700;
+  height: 2rem;
+  padding: 0 0.75rem;
+  position: relative;
 
   :hover {
     border: ${({ theme, active, warning }) =>
@@ -77,6 +79,7 @@ const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }
   }
 
   input {
+    background-color: inherit;
     width: 100%;
     height: 100%;
     border: 0px;
@@ -89,7 +92,7 @@ const OptionCustomTime = styled(FancyButton)<{ active?: boolean; warning?: boole
   position: relative;
   flex: 1;
   border: ${({ theme, active, warning }) => (active ? `1px solid ${warning ? theme.red1 : '#35404E'}` : '#35404E')};
-  background: #35404e;
+  background-color: #35404e;
   font-weight: 700;
   margin-right: 0.5rem;
 
@@ -104,7 +107,7 @@ const OptionCustomTime = styled(FancyButton)<{ active?: boolean; warning?: boole
     border: 0px;
     border-radius: 12px;
     font-weight: 700;
-    background: #35404e;
+    background-color: inherit;
   }
 `
 
@@ -114,6 +117,8 @@ const SlippageEmojiContainer = styled.span`
     display: none;  
   `}
 `
+
+const slippageDefaults = [10, 50, 100]
 
 export interface SlippageTabsProps {
   rawSlippage: number
@@ -127,7 +132,9 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
 
   const inputRef = useRef<HTMLInputElement>()
 
-  const [slippageInput, setSlippageInput] = useState('')
+  const [slippageInput, setSlippageInput] = useState(
+    !slippageDefaults.includes(rawSlippage) ? `${rawSlippage / 100}` : ''
+  )
   const [deadlineInput, setDeadlineInput] = useState('')
 
   const slippageInputIsValid =
@@ -151,6 +158,7 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
   } else {
     deadlineError = undefined
   }
+  console.log('raw slippage', rawSlippage)
 
   function parseCustomSlippage(value: string) {
     setSlippageInput(value)
@@ -184,33 +192,18 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
           <QuestionHelper text="Your transaction will revert if the price changes unfavorably by more than this percentage." />
         </StyledRowFixed>
         <RowBetween>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(10)
-            }}
-            active={rawSlippage === 10}
-          >
-            0.1%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(50)
-            }}
-            active={rawSlippage === 50}
-          >
-            0.5%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(100)
-            }}
-            active={rawSlippage === 100}
-          >
-            1%
-          </Option>
+          {slippageDefaults.map((slippageValue: number) => (
+            <Option
+              onClick={() => {
+                setSlippageInput('')
+                setRawSlippage(slippageValue)
+              }}
+              active={rawSlippage === slippageValue}
+              key={slippageValue}
+            >
+              {slippageValue / 100}%
+            </Option>
+          ))}
           <OptionCustom active={![10, 50, 100].includes(rawSlippage)} warning={!slippageInputIsValid} tabIndex={-1}>
             <RowBetween>
               {!!slippageInput &&

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -158,7 +158,6 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
   } else {
     deadlineError = undefined
   }
-  console.log('raw slippage', rawSlippage)
 
   function parseCustomSlippage(value: string) {
     setSlippageInput(value)


### PR DESCRIPTION
Fix for user reported issue:

New mistX QA Report 

Environment
Device: Mac
Browser: Brave
Wallet Hardware: No

Description of issue
Custom slippage cannot be set
Steps to replicate
Just open the settings in mistX and try to add a custom slippage than close settings and open again. The custom slippage field is empty. By uni it's the placeholder of the same field that shows the value set. Here it only shows "Custom".
Upload:


submitted by: admnrqst