### PR TITLE
Remove 'swap anyway' on swap component

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -136,7 +136,7 @@ const StyledButtonError = styled(ButtonError)<{ disabled: boolean }>`
 
   &:before,
   &:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => theme.primary2};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? theme.red1 : theme.primary2)};
     content: '';
     height: 44px;
     position: absolute;
@@ -158,12 +158,12 @@ const StyledButtonError = styled(ButtonError)<{ disabled: boolean }>`
   &:focus:after,
   &:hover:before,
   &:hover:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => darken(0.05, theme.primary2)};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? darken(0.05, theme.red1) : darken(0.05, theme.primary2))};
   }
 
   &:active:before,
   &:active:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => darken(0.1, theme.primary2)};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? darken(0.1, theme.red1) : darken(0.1, theme.primary2))};
   }
 `
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -711,14 +711,13 @@ export default function Swap({ history }: RouteComponentProps) {
                       onClick={swapButtonAction}
                       id="swap-button"
                       disabled={!isValid || (priceImpactSeverity > 3 && !isExpertMode) || !!swapCallbackError}
-                      error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
                     >
                       <Text fontSize={20} fontWeight={700}>
                         {swapInputError
                           ? swapInputError
                           : priceImpactSeverity > 3 && !isExpertMode
                           ? `Price Impact Too High`
-                          : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                          : `Swap`}
                       </Text>
                     </StyledButtonError>
                   )}


### PR DESCRIPTION
The 'Swap Anyway' text on the main swap component doesn't provide value as there is no context to the price impact in this view. We do show the price impact in the swap confirmation modal, where we still show the 'swap anyway' confirmation.

- Remove ' Anyway' from swap components and the 'error' state on that button
- Fix color of the stylistic curves on the button when there is an 'error' state