### PR TITLE
v0.1.4 

### DIFF
--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -14,9 +14,33 @@ const Container = styled.div`
   left: 30px;
   height: 43px;
   width: auto;
+
+  &:before {
+    content: '';
+    position: absolute;
+    height: 43px;
+    top: 0;
+    bottom: 0;
+    left: -15px;
+    right: 0;
+    height: auto;
+    width: auto;
+    border: 2px solid #ba900e;
+    border-radius: 30px 0 0 30px;
+  }
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    left: 0;
+    &:before {
+      right: 0;
+      left: -30px;
+      padding: 0;
+      border-radius: 0 30px 30px 0; 
+    }
+  `};
 `
 
-const Left = styled.div`
+const Wrapper = styled.div`
   position: relative;
   display: flex;
   min-width: 40px;
@@ -25,10 +49,9 @@ const Left = styled.div`
   flex-direction: column;
   width: auto;
   height: 43px;
-  border: 2px solid #ba900e;
   border-right: 0;
   border-radius: 0;
-  padding: 7px 0 7px 14px;
+  padding: 0 30px 0 0;
   border-radius: 30px 0 0 30px;
   font-weight: 600;
   color: #fff;
@@ -36,15 +59,11 @@ const Left = styled.div`
   justify-content: center;
   white-space: pre;
   cursor: pointer;
-`
 
-const Right = styled.div`
-  position: relative;
-  display: flex;
-  width: 30px;
-  height: 43px;
-  border: 2px solid #ba900e;
-  border-left: 0;
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    padding: 0 20px 0px 0px;
+    border-radius: 0;
+  `};
 `
 
 const StyledLoader = styled(Loader)`
@@ -60,14 +79,13 @@ const MistBalance = () => {
   if (!account) return null
   return (
     <Container>
-      <Left onClick={handleOutputSelect}>
+      <Wrapper onClick={handleOutputSelect}>
         {account && !mistBalance ? (
           <StyledLoader stroke="#fff" size="20px" />
         ) : (
           <> {mistBalance ? mistBalance : '0'} MIST</>
         )}
-      </Left>
-      <Right />
+      </Wrapper>
     </Container>
   )
 }

--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useCurrencyBalance } from '../../state/wallet/hooks'
+import { useAlchmeistToken } from '../../state/lists/hooks'
+import { useActiveWeb3React } from '../../hooks'
+import Loader from 'components/Loader'
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: revert;
+  left: 30px;
+  height: 43px;
+  width: auto;
+`
+
+const Left = styled.a`
+  position: relative;
+  display: flex;
+  min-width: 95px;
+  align-content: center;
+  justify-items: center;
+  flex-direction: column;
+  width: auto;
+  height: 43px;
+  border: 2px solid #f7b903;
+  border-right: 0;
+  border-radius: 0;
+  padding: 7px 0 7px 14px;
+  border-radius: 30px 0 0 30px;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+  justify-content: center;
+`
+
+const Right = styled.div`
+  position: relative;
+  display: flex;
+  width: 30px;
+  height: 43px;
+  border: 2px solid #f7b903;
+  border-left: 0;
+`
+
+const StyledLoader = styled(Loader)`
+  display: flex;
+`
+const MistBalance = () => {
+  const { account } = useActiveWeb3React()
+  const alchemistToken = useAlchmeistToken(1) // default ot mainnet as there is no mist token on other networks - value will fallback to 0 on other networks
+  const balance = useCurrencyBalance(account ?? undefined, alchemistToken.token)
+  const mistBalance = balance?.toSignificant(2)
+  return (
+    <Container>
+      <Left href={`${window.location.origin}/exchange?outputCurrency=0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB`}>
+        {!account || !mistBalance ? (
+          <StyledLoader stroke="#fff" size="20px" />
+        ) : (
+          <> {mistBalance ? mistBalance : '0'} MIST</>
+        )}
+      </Left>
+      <Right />
+    </Container>
+  )
+}
+
+export default MistBalance

--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Field } from '../../state/swap/actions'
 import { useCurrencyBalance } from '../../state/wallet/hooks'
 import { useAlchmeistToken } from '../../state/lists/hooks'
 import { useActiveWeb3React } from '../../hooks'
+import { useSwapActionHandlers } from '../../state/swap/hooks'
 import Loader from 'components/Loader'
 
 const Container = styled.div`
@@ -14,7 +16,7 @@ const Container = styled.div`
   width: auto;
 `
 
-const Left = styled.a`
+const Left = styled.div`
   position: relative;
   display: flex;
   min-width: 40px;
@@ -23,7 +25,7 @@ const Left = styled.a`
   flex-direction: column;
   width: auto;
   height: 43px;
-  border: 2px solid ${({ theme }) => theme.primary1};
+  border: 2px solid #ba900e;
   border-right: 0;
   border-radius: 0;
   padding: 7px 0 7px 14px;
@@ -33,6 +35,7 @@ const Left = styled.a`
   text-decoration: none;
   justify-content: center;
   white-space: pre;
+  cursor: pointer;
 `
 
 const Right = styled.div`
@@ -40,7 +43,7 @@ const Right = styled.div`
   display: flex;
   width: 30px;
   height: 43px;
-  border: 2px solid ${({ theme }) => theme.primary1};
+  border: 2px solid #ba900e;
   border-left: 0;
 `
 
@@ -49,13 +52,15 @@ const StyledLoader = styled(Loader)`
 `
 const MistBalance = () => {
   const { account } = useActiveWeb3React()
+  const { onCurrencySelection } = useSwapActionHandlers()
   const alchemistToken = useAlchmeistToken(1) // default ot mainnet as there is no mist token on other networks - value will fallback to 0 on other networks
   const balance = useCurrencyBalance(account ?? undefined, alchemistToken.token)
   const mistBalance = balance?.toSignificant(2)
+  const handleOutputSelect = () => onCurrencySelection(Field.OUTPUT, alchemistToken.token)
   if (!account) return null
   return (
     <Container>
-      <Left href={`${window.location.origin}/exchange?outputCurrency=0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB`}>
+      <Left onClick={handleOutputSelect}>
         {account && !mistBalance ? (
           <StyledLoader stroke="#fff" size="20px" />
         ) : (

--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -23,7 +23,7 @@ const Left = styled.a`
   flex-direction: column;
   width: auto;
   height: 43px;
-  border: 2px solid #f7b903;
+  border: 2px solid ${({ theme }) => theme.primary1};
   border-right: 0;
   border-radius: 0;
   padding: 7px 0 7px 14px;
@@ -40,7 +40,7 @@ const Right = styled.div`
   display: flex;
   width: 30px;
   height: 43px;
-  border: 2px solid #f7b903;
+  border: 2px solid ${({ theme }) => theme.primary1};
   border-left: 0;
 `
 

--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
 const Left = styled.a`
   position: relative;
   display: flex;
-  min-width: 95px;
+  min-width: 40px;
   align-content: center;
   justify-items: center;
   flex-direction: column;
@@ -32,6 +32,7 @@ const Left = styled.a`
   color: #fff;
   text-decoration: none;
   justify-content: center;
+  white-space: pre;
 `
 
 const Right = styled.div`

--- a/src/components/MistBalance/index.tsx
+++ b/src/components/MistBalance/index.tsx
@@ -51,10 +51,11 @@ const MistBalance = () => {
   const alchemistToken = useAlchmeistToken(1) // default ot mainnet as there is no mist token on other networks - value will fallback to 0 on other networks
   const balance = useCurrencyBalance(account ?? undefined, alchemistToken.token)
   const mistBalance = balance?.toSignificant(2)
+  if (!account) return null
   return (
     <Container>
       <Left href={`${window.location.origin}/exchange?outputCurrency=0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB`}>
-        {!account || !mistBalance ? (
+        {account && !mistBalance ? (
           <StyledLoader stroke="#fff" size="20px" />
         ) : (
           <> {mistBalance ? mistBalance : '0'} MIST</>

--- a/src/components/NetworkWarningModal/index.tsx
+++ b/src/components/NetworkWarningModal/index.tsx
@@ -21,6 +21,10 @@ export default function NetworkWarningModal() {
 
   const { chainId } = useActiveWeb3React()
 
+  function handleClose() {
+    // do nothing
+  }
+
   useEffect(() => {
     if (chainId && chainId !== NETWORK_CHAIN_ID) {
       setIsOpen(true)
@@ -32,7 +36,7 @@ export default function NetworkWarningModal() {
   if (!isOpen || !chainId) return null
 
   return (
-    <Modal isOpen={isOpen} onDismiss={() => {}}>
+    <Modal isOpen={isOpen} onDismiss={handleClose}>
       <Wrapper>
         <Section>
           <RowBetween>

--- a/src/components/NetworkWarningModal/index.tsx
+++ b/src/components/NetworkWarningModal/index.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Text } from 'rebass'
+import { RowBetween } from '../Row'
+import { AutoColumn } from '../Column'
+import { useActiveWeb3React } from 'hooks'
+import { NETWORK_CHAIN_ID } from 'connectors'
+import Modal from 'components/Modal'
+import { NETWORK_LABELS } from 'components/WalletConnect'
+import { AlertTriangle } from 'react-feather'
+
+const Wrapper = styled.div`
+  width: 100%;
+`
+const Section = styled(AutoColumn)`
+  padding: 24px;
+`
+
+export default function NetworkWarningModal() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const { chainId } = useActiveWeb3React()
+
+  useEffect(() => {
+    if (chainId && chainId !== NETWORK_CHAIN_ID) {
+      setIsOpen(true)
+    } else {
+      setIsOpen(false)
+    }
+  }, [chainId])
+
+  if (!isOpen || !chainId) return null
+
+  return (
+    <Modal isOpen={isOpen} onDismiss={() => {}}>
+      <Wrapper>
+        <Section>
+          <RowBetween>
+            <Text fontWeight={500} fontSize={24}>
+              Wrong Network!
+            </Text>
+            <AlertTriangle size={20} />
+          </RowBetween>
+          <RowBetween margin="1rem 0 0" flexDirection="column">
+            <Text fontWeight={300} fontSize={18}>
+              {`Check your wallet's selected network and make sure you are connected to `}
+              <b>{(NETWORK_CHAIN_ID === 1 && 'Ethereum Mainnet') || (NETWORK_CHAIN_ID === 5 && 'Görli')}</b>
+            </Text>
+          </RowBetween>
+          <RowBetween margin="1rem 0 0" flexDirection="column">
+            <Text fontWeight={300} fontSize={12} fontStyle="italic">
+              {`Your current network (${NETWORK_LABELS[chainId]}) isn't supported.`}
+            </Text>
+          </RowBetween>
+        </Section>
+      </Wrapper>
+    </Modal>
+  )
+}

--- a/src/components/SearchModal/CurrencyList.tsx
+++ b/src/components/SearchModal/CurrencyList.tsx
@@ -152,7 +152,7 @@ function CurrencyRow({
   const isOnSelectedList = isTokenOnList(selectedTokenList, currency)
   const customAdded = useIsUserAddedToken(currency)
   const balance = useCurrencyBalance(account ?? undefined, currency)
-  
+
   // only show add or remove buttons if not on selected list
   return (
     <MenuItem

--- a/src/components/SearchModal/CurrencyList.tsx
+++ b/src/components/SearchModal/CurrencyList.tsx
@@ -152,7 +152,7 @@ function CurrencyRow({
   const isOnSelectedList = isTokenOnList(selectedTokenList, currency)
   const customAdded = useIsUserAddedToken(currency)
   const balance = useCurrencyBalance(account ?? undefined, currency)
-
+  
   // only show add or remove buttons if not on selected list
   return (
     <MenuItem

--- a/src/components/Settings/Slider.tsx
+++ b/src/components/Settings/Slider.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useContext, useEffect } from 'react'
 import { Range, getTrackBackground } from 'react-range'
 import { ThemeContext } from 'styled-components'
+import { useSelector } from 'react-redux'
 import { BribeEstimate, WETH, TokenAmount } from '@alchemistcoin/sdk'
 import useMinerBribeEstimate from '../../hooks/useMinerBribeEstimate'
 import useUSDCPrice from '../../hooks/useUSDCPrice'
+import { AppState } from '../../state'
 
 type Props = {
   max: number
@@ -46,17 +48,27 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
   const [sliderThumbLabel, setSliderThumbLabel] = useState<string>('')
   const bribeEstimate: BribeEstimate | null = useMinerBribeEstimate()
   const ethUSDCPrice = useUSDCPrice(WETH[1])
+  const feeDisplayCurrency = useSelector<AppState, AppState['user']['feeDisplayCurrency']>(
+    state => state.user.feeDisplayCurrency
+  )
+
   useEffect(() => {
-    let label = '.....'
+    let label = 'Fetching price...'
     if (bribeEstimate && ethUSDCPrice) {
       const minBribeTokenAmount = new TokenAmount(WETH[1], bribeEstimate.minBribe.raw)
       const maxBribeTokenAmount = new TokenAmount(WETH[1], bribeEstimate.maxBribe.raw)
-      label = `$${ethUSDCPrice.quote(minBribeTokenAmount).toSignificant(2)} - $${ethUSDCPrice
-        .quote(maxBribeTokenAmount)
-        .toSignificant(2)}`
+
+      if (feeDisplayCurrency === 'USD') {
+        label = `$${ethUSDCPrice.quote(minBribeTokenAmount).toSignificant(2)} - $${ethUSDCPrice
+          .quote(maxBribeTokenAmount)
+          .toSignificant(2)}`
+      } else {
+        label = `${Number(minBribeTokenAmount.toSignificant(2))} - ${Number(maxBribeTokenAmount.toSignificant(2))}`
+      }
     }
     setSliderThumbLabel(label)
-  }, [bribeEstimate, ethUSDCPrice])
+  }, [bribeEstimate, ethUSDCPrice, feeDisplayCurrency])
+
   const onSliderChange = (values: any) => {
     setSliderValue(values)
     onChange(values[0])
@@ -171,7 +183,8 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
                 top: '16px',
                 zIndex: 1,
                 borderRadius: '4px',
-                background: '#192431'
+                background: '#192431',
+                cursor: 'pointer'
               }}
             />
           </div>
@@ -200,8 +213,9 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
                 fontWeight: 700,
                 fontSize: '14px',
                 borderRadius: '4px',
-                backgroundColor: '#FFF',
-                color: theme.text5,
+                backgroundColor: '#222e3b',
+                border: '1px solid #ffbf01',
+                color: theme.text1,
                 padding: '0.25rem 0.5rem',
                 cursor: 'pointer',
                 minWidth: '150px',
@@ -214,12 +228,11 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
                   position: 'absolute',
                   bottom: '-7px',
                   left: '50%',
-                  height: '9px',
                   marginLeft: '-8px',
                   fontWeight: 700,
                   zIndex: 2,
                   borderLeft: '8px solid transparent',
-                  borderTop: '8px solid #fff',
+                  borderTop: '7px solid #ffbf01',
                   borderRight: '8px solid transparent'
                 }}
               />

--- a/src/components/Settings/Slider.tsx
+++ b/src/components/Settings/Slider.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useContext, useEffect } from 'react'
 import { Range, getTrackBackground } from 'react-range'
 import { ThemeContext } from 'styled-components'
-import { useSelector } from 'react-redux'
 import { BribeEstimate, WETH, TokenAmount } from '@alchemistcoin/sdk'
 import useMinerBribeEstimate from '../../hooks/useMinerBribeEstimate'
 import useUSDCPrice from '../../hooks/useUSDCPrice'
-import { AppState } from '../../state'
+import useFeeDisplayCurrency from '../../hooks/useFeeDisplayCurrency'
 
 type Props = {
   max: number
@@ -48,9 +47,7 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
   const [sliderThumbLabel, setSliderThumbLabel] = useState<string>('')
   const bribeEstimate: BribeEstimate | null = useMinerBribeEstimate()
   const ethUSDCPrice = useUSDCPrice(WETH[1])
-  const feeDisplayCurrency = useSelector<AppState, AppState['user']['feeDisplayCurrency']>(
-    state => state.user.feeDisplayCurrency
-  )
+  const feeDisplayCurrency = useFeeDisplayCurrency()
 
   useEffect(() => {
     let label = 'Fetching price...'

--- a/src/components/Settings/Slider.tsx
+++ b/src/components/Settings/Slider.tsx
@@ -204,11 +204,25 @@ const Slider = ({ max, min, onChange, value, step }: Props) => {
                 color: theme.text5,
                 padding: '0.25rem 0.5rem',
                 cursor: 'pointer',
-                width: '100px',
+                minWidth: '150px',
                 textAlign: 'center',
                 zIndex: 3
               }}
             >
+              <span
+                style={{
+                  position: 'absolute',
+                  bottom: '-7px',
+                  left: '50%',
+                  height: '9px',
+                  marginLeft: '-8px',
+                  fontWeight: 700,
+                  zIndex: 2,
+                  borderLeft: '8px solid transparent',
+                  borderTop: '8px solid #fff',
+                  borderRight: '8px solid transparent'
+                }}
+              />
               {sliderThumbLabel}
             </div>
             <div

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -199,7 +199,7 @@ export default function SettingsTab() {
             </AutoColumn>
           </ModalContentWrapper>
         </Modal>
-        <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
+        <StyledMenuButton onClick={() => !open && toggle()} id="open-settings-dialog-button">
           <StyledMenuIcon>{open ? <Close /> : <Cog />}</StyledMenuIcon>
           {expertMode ? (
             <EmojiWrapper>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useRef, useState } from 'react'
 import { X } from 'react-feather'
 import ReactGA from 'react-ga'
 import { Text } from 'rebass'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { lighten, rem, darken } from 'polished'
 import styled, { ThemeContext } from 'styled-components'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
@@ -15,7 +15,6 @@ import {
   useUserSlippageTolerance,
   useUserSingleHopOnly
 } from '../../state/user/hooks'
-import { AppState } from '../../state'
 import { TYPE } from '../../theme'
 // components
 import { SettingsHeader, SettingsHeaderEnd } from '../shared/header/styled'
@@ -28,6 +27,7 @@ import Toggle from '../Toggle'
 import MinerBribeSlider from './MinerBribeSlider'
 import TransactionSettings from '../TransactionSettings'
 import { Cog, Close } from '../Icons'
+import useFeeDisplayCurrency from '../../hooks/useFeeDisplayCurrency'
 
 const StyledCloseIcon = styled(X)`
   height: 20px;
@@ -209,9 +209,7 @@ export default function SettingsTab() {
 
   useOnClickOutside(node, open ? toggle : undefined)
 
-  const feeDisplayCurrency = useSelector<AppState, AppState['user']['feeDisplayCurrency']>(
-    state => state.user.feeDisplayCurrency
-  )
+  const feeDisplayCurrency = useFeeDisplayCurrency()
 
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
   return (

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,11 +1,13 @@
-import React, { useContext, useRef, useState, useEffect } from 'react'
+import React, { useContext, useRef, useState } from 'react'
 import { X } from 'react-feather'
 import ReactGA from 'react-ga'
 import { Text } from 'rebass'
+import { useSelector, useDispatch } from 'react-redux'
 import { lighten, rem, darken } from 'polished'
 import styled, { ThemeContext } from 'styled-components'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import { ApplicationModal } from '../../state/application/actions'
+import { updateFeeDisplayCurrency } from '../../state/user/actions'
 import { useModalOpen, useToggleSettingsMenu } from '../../state/application/hooks'
 import {
   useExpertModeManager,
@@ -13,6 +15,7 @@ import {
   useUserSlippageTolerance,
   useUserSingleHopOnly
 } from '../../state/user/hooks'
+import { AppState } from '../../state'
 import { TYPE } from '../../theme'
 // components
 import { SettingsHeader, SettingsHeaderEnd } from '../shared/header/styled'
@@ -183,6 +186,7 @@ const ToggleButton = styled.button<{ active: boolean }>`
 `
 
 export default function SettingsTab() {
+  const dispatch = useDispatch()
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.SETTINGS)
   const toggle = useToggleSettingsMenu()
@@ -201,15 +205,9 @@ export default function SettingsTab() {
 
   useOnClickOutside(node, open ? toggle : undefined)
 
-  const [feeCurrency, setFeeCurrency] = useState<'ETH' | 'USDC'>('USDC')
-  const toggleFeeCurrency = (token: any): void => {
-    console.log('toggleFeeCurrency', token)
-    setFeeCurrency(token)
-  }
-
-  useEffect(() => {
-    console.log('useEffect')
-  }, [feeCurrency])
+  const feeDisplayCurrency = useSelector<AppState, AppState['user']['feeDisplayCurrency']>(
+    state => state.user.feeDisplayCurrency
+  )
 
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
   return (
@@ -273,11 +271,17 @@ export default function SettingsTab() {
                     <QuestionHelper text="A tip for the miner to accept the transaction. Higher tips are more likely to be accepted." />
                   </Text>
                   <SettingsHeaderEnd>
-                    <ToggleButton onClick={() => toggleFeeCurrency('ETH')} active={feeCurrency === 'ETH'}>
-                      ETH
-                    </ToggleButton>
-                    <ToggleButton onClick={() => toggleFeeCurrency('USDC')} active={feeCurrency === 'USDC'}>
+                    <ToggleButton
+                      onClick={() => dispatch(updateFeeDisplayCurrency('USD'))}
+                      active={feeDisplayCurrency === 'USD'}
+                    >
                       USD
+                    </ToggleButton>
+                    <ToggleButton
+                      onClick={() => dispatch(updateFeeDisplayCurrency('ETH'))}
+                      active={feeDisplayCurrency === 'ETH'}
+                    >
+                      ETH
                     </ToggleButton>
                   </SettingsHeaderEnd>
                 </SettingsHeader>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -137,6 +137,10 @@ const ModalContentWrapper = styled.div`
 const SettingWrapper = styled.div<{ darkBg?: boolean }>`
   padding: 1.5rem 1.5rem;
   background-color: ${({ theme, darkBg }) => darkBg && '#232E3B'};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 1.5rem 1rem;
+  `}
 `
 
 const StyledRowFixed = styled(RowFixed)`

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useRef, useState } from 'react'
+import React, { useContext, useRef, useState, useEffect } from 'react'
 import { X } from 'react-feather'
 import ReactGA from 'react-ga'
 import { Text } from 'rebass'
-import { lighten, rem } from 'polished'
+import { lighten, rem, darken } from 'polished'
 import styled, { ThemeContext } from 'styled-components'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import { ApplicationModal } from '../../state/application/actions'
@@ -15,7 +15,7 @@ import {
 } from '../../state/user/hooks'
 import { TYPE } from '../../theme'
 // components
-import { SettingsHeader } from '../shared/header/styled'
+import { SettingsHeader, SettingsHeaderEnd } from '../shared/header/styled'
 import { ButtonError } from '../Button'
 import { AutoColumn } from '../Column'
 import Modal from '../Modal'
@@ -140,6 +140,48 @@ const StyledRowFixed = styled(RowFixed)`
   width: 100%;
 `
 
+const ToggleButton = styled.button<{ active: boolean }>`
+  color: ${({ theme }) => theme.text1};
+  align-items: center;
+  height: 2rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  width: auto;
+  min-width: 3.5rem;
+  border: 1px solid ${({ theme }) => theme.primary2};
+  outline: none;
+  background: transparent;
+  font-weight: 600;
+  background: transparent;
+  cursor: pointer;
+  color: ${({ theme }) => theme.text1};
+
+  ${({ active, theme }) =>
+    active &&
+    `
+      background: ${theme.primary2};
+      color: ${theme.text5};
+  `}
+
+  &:first-child {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: 0;
+  }
+
+  &:last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  :hover {
+    border-color: solid ${({ theme }) => darken(0.1, theme.primary2)};
+  }
+  :focus {
+    background: ${({ theme }) => darken(0.1, theme.primary2)};
+  }
+`
+
 export default function SettingsTab() {
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.SETTINGS)
@@ -158,6 +200,16 @@ export default function SettingsTab() {
   const [showConfirmation, setShowConfirmation] = useState(false)
 
   useOnClickOutside(node, open ? toggle : undefined)
+
+  const [feeCurrency, setFeeCurrency] = useState<'ETH' | 'USDC'>('USDC')
+  const toggleFeeCurrency = (token: any): void => {
+    console.log('toggleFeeCurrency', token)
+    setFeeCurrency(token)
+  }
+
+  useEffect(() => {
+    console.log('useEffect')
+  }, [feeCurrency])
 
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
   return (
@@ -217,9 +269,17 @@ export default function SettingsTab() {
               <StyledRowFixed>
                 <SettingsHeader>
                   <Text fontWeight={600} fontSize={20}>
-                    Transaction Fee (ETH)
+                    Transaction Fee
+                    <QuestionHelper text="A tip for the miner to accept the transaction. Higher tips are more likely to be accepted." />
                   </Text>
-                  <QuestionHelper text="A tip for the miner to accept the transaction. Higher tips are more likely to be accepted." />
+                  <SettingsHeaderEnd>
+                    <ToggleButton onClick={() => toggleFeeCurrency('ETH')} active={feeCurrency === 'ETH'}>
+                      ETH
+                    </ToggleButton>
+                    <ToggleButton onClick={() => toggleFeeCurrency('USDC')} active={feeCurrency === 'USDC'}>
+                      USD
+                    </ToggleButton>
+                  </SettingsHeaderEnd>
                 </SettingsHeader>
               </StyledRowFixed>
               <MinerBribeSlider />

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -217,7 +217,7 @@ export default function SettingsTab() {
               <StyledRowFixed>
                 <SettingsHeader>
                   <Text fontWeight={600} fontSize={20}>
-                    Transaction Fee (ETH)
+                    Transaction Fee
                   </Text>
                   <QuestionHelper text="A tip for the miner to accept the transaction. Higher tips are more likely to be accepted." />
                 </SettingsHeader>

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -65,11 +65,13 @@ const Input = styled.input`
 `
 
 const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }>`
-  height: 2rem;
-  position: relative;
-  padding: 0 0.75rem;
+  border: ${({ theme, active, warning }) => (active ? `1px solid ${warning ? theme.red1 : '#35404E'}` : '#35404E')};
+  background-color: #35404e;
   flex: 1;
-  border: ${({ theme, active, warning }) => active && `1px solid ${warning ? theme.red1 : theme.primary2}`};
+  font-weight: 700;
+  height: 2rem;
+  padding: 0 0.75rem;
+  position: relative;
 
   :hover {
     border: ${({ theme, active, warning }) =>
@@ -77,6 +79,7 @@ const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }
   }
 
   input {
+    background-color: inherit;
     width: 100%;
     height: 100%;
     border: 0px;
@@ -89,7 +92,7 @@ const OptionCustomTime = styled(FancyButton)<{ active?: boolean; warning?: boole
   position: relative;
   flex: 1;
   border: ${({ theme, active, warning }) => (active ? `1px solid ${warning ? theme.red1 : '#35404E'}` : '#35404E')};
-  background: #35404e;
+  background-color: #35404e;
   font-weight: 700;
   margin-right: 0.5rem;
 
@@ -104,7 +107,7 @@ const OptionCustomTime = styled(FancyButton)<{ active?: boolean; warning?: boole
     border: 0px;
     border-radius: 12px;
     font-weight: 700;
-    background: #35404e;
+    background-color: inherit;
   }
 `
 
@@ -114,6 +117,8 @@ const SlippageEmojiContainer = styled.span`
     display: none;  
   `}
 `
+
+const slippageDefaults = [10, 50, 100]
 
 export interface SlippageTabsProps {
   rawSlippage: number
@@ -127,7 +132,9 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
 
   const inputRef = useRef<HTMLInputElement>()
 
-  const [slippageInput, setSlippageInput] = useState('')
+  const [slippageInput, setSlippageInput] = useState(
+    !slippageDefaults.includes(rawSlippage) ? `${rawSlippage / 100}` : ''
+  )
   const [deadlineInput, setDeadlineInput] = useState('')
 
   const slippageInputIsValid =
@@ -151,6 +158,7 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
   } else {
     deadlineError = undefined
   }
+  console.log('raw slippage', rawSlippage)
 
   function parseCustomSlippage(value: string) {
     setSlippageInput(value)
@@ -184,33 +192,18 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
           <QuestionHelper text="Your transaction will revert if the price changes unfavorably by more than this percentage." />
         </StyledRowFixed>
         <RowBetween>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(10)
-            }}
-            active={rawSlippage === 10}
-          >
-            0.1%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(50)
-            }}
-            active={rawSlippage === 50}
-          >
-            0.5%
-          </Option>
-          <Option
-            onClick={() => {
-              setSlippageInput('')
-              setRawSlippage(100)
-            }}
-            active={rawSlippage === 100}
-          >
-            1%
-          </Option>
+          {slippageDefaults.map((slippageValue: number) => (
+            <Option
+              onClick={() => {
+                setSlippageInput('')
+                setRawSlippage(slippageValue)
+              }}
+              active={rawSlippage === slippageValue}
+              key={slippageValue}
+            >
+              {slippageValue / 100}%
+            </Option>
+          ))}
           <OptionCustom active={![10, 50, 100].includes(rawSlippage)} warning={!slippageInputIsValid} tabIndex={-1}>
             <RowBetween>
               {!!slippageInput &&

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -158,7 +158,6 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
   } else {
     deadlineError = undefined
   }
-  console.log('raw slippage', rawSlippage)
 
   function parseCustomSlippage(value: string) {
     setSlippageInput(value)

--- a/src/components/WalletConnect/index.tsx
+++ b/src/components/WalletConnect/index.tsx
@@ -6,6 +6,7 @@ import { useActiveWeb3React } from '../../hooks'
 import { YellowCard } from '../Card'
 import Menu from '../Menu'
 import Web3Status from '../Web3Status'
+import MistBalance from '../MistBalance'
 
 const HeaderFrame = styled.div`
   display: flex;
@@ -151,6 +152,7 @@ export default function Header() {
               <NetworkCard title={NETWORK_LABELS[chainId]}>{NETWORK_LABELS[chainId]}</NetworkCard>
             )}
           </HideSmall>
+          <MistBalance />
           <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
             <Web3Status />
           </AccountElement>

--- a/src/components/WalletConnect/index.tsx
+++ b/src/components/WalletConnect/index.tsx
@@ -129,7 +129,7 @@ export const StyledMenuButton = styled.button`
   }
 `
 
-const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
+export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
   [ChainId.ROPSTEN]: 'Ropsten',
   [ChainId.GÖRLI]: 'Görli',

--- a/src/components/shared/header/styled.tsx
+++ b/src/components/shared/header/styled.tsx
@@ -7,6 +7,12 @@ export const SettingsHeader = styled.div`
   margin: 0 0 1.5rem;
   color: ${({ theme }) => theme.text1};
   align-items: center;
+  justify-content: space-between;
+
+  > div {
+    display: flex;
+    flex-direction: row;
+  }
 
   &:before {
     position: absolute;
@@ -17,4 +23,10 @@ export const SettingsHeader = styled.div`
     content: '';
     background-color: ${({ theme }) => theme.primary2};
   }
+`
+
+export const SettingsHeaderEnd = styled.div`
+  position: relative;
+  display: flex;
+  align-self: flex-end;
 `

--- a/src/components/shared/header/styled.tsx
+++ b/src/components/shared/header/styled.tsx
@@ -22,6 +22,10 @@ export const SettingsHeader = styled.div`
     width: 2px;
     content: '';
     background-color: ${({ theme }) => theme.primary2};
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      left: -1rem
+   `}
   }
 `
 

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -104,8 +104,6 @@ export default function SwapModalFooter({
       : slippageAdjustedAmounts[Field.OUTPUT]?.currency
   )
 
-  console.log('tradeToken price', tokenUSDCPrice, tokenUSDCPrice?.toSignificant(4))
-
   return (
     <>
       <PriceWrapper>

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -98,11 +98,13 @@ export default function SwapModalFooter({
   const { priceImpactWithoutFee, realizedLPFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const severity = warningSeverity(priceImpactWithoutFee)
   const minerBribeEth = new TokenAmount(WETH[1], trade.minerBribe.raw)
-  const tokenUSDCPrice = useUSDCPrice(
+  const tokenCurrency =
     trade.tradeType === TradeType.EXACT_INPUT
       ? slippageAdjustedAmounts[Field.INPUT]?.currency
       : slippageAdjustedAmounts[Field.OUTPUT]?.currency
-  )
+  const tokenUSDCPrice = useUSDCPrice(tokenCurrency)
+
+  console.log('swap modal', tokenCurrency, realizedLPFee)
 
   return (
     <>
@@ -181,14 +183,14 @@ export default function SwapModalFooter({
           <TYPE.black fontSize={14} fontWeight={700}>
             {realizedLPFee ? realizedLPFee?.toSignificant(6) + ' ' + trade.inputAmount.currency.symbol : '-'}
             &nbsp;&nbsp;
-            {realizedLPFee && ethUSDCPrice
+            {realizedLPFee && ethUSDCPrice && tokenCurrency && realizedLPFee.currency.symbol !== tokenCurrency.symbol
               ? '(' +
                 tokenUSDCPrice
                   ?.divide(ethUSDCPrice || '0x1')
                   .multiply(realizedLPFee)
                   .toSignificant(2) +
                 ' ETH)'
-              : '-'}
+              : ''}
           </TYPE.black>
         </RowBetween>
         <RowBetween>

--- a/src/components/swap/SwapModalFooter.tsx
+++ b/src/components/swap/SwapModalFooter.tsx
@@ -104,8 +104,6 @@ export default function SwapModalFooter({
       : slippageAdjustedAmounts[Field.OUTPUT]?.currency
   const tokenUSDCPrice = useUSDCPrice(tokenCurrency)
 
-  console.log('swap modal', tokenCurrency, realizedLPFee)
-
   return (
     <>
       <PriceWrapper>

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -14,7 +14,7 @@ const FORMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY
 const PORTIS_ID = process.env.REACT_APP_PORTIS_ID
 const WALLETCONNECT_BRIDGE_URL = process.env.REACT_APP_WALLETCONNECT_BRIDGE_URL
 
-export const NETWORK_CHAIN_ID: number = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
+export const NETWORK_CHAIN_ID: number = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1', 10)
 
 if (typeof NETWORK_URL === 'undefined') {
   throw new Error(`REACT_APP_NETWORK_URL must be a defined environment variable`)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -57,6 +57,8 @@ export function useAllTokens(): { [address: string]: Token } {
   return useTokensFromMap(allTokens, true)
 }
 
+
+
 export function useUnsupportedTokens(): { [address: string]: Token } {
   const unsupportedTokensMap = useUnsupportedTokenList()
   return useTokensFromMap(unsupportedTokensMap, false)

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -57,8 +57,6 @@ export function useAllTokens(): { [address: string]: Token } {
   return useTokensFromMap(allTokens, true)
 }
 
-
-
 export function useUnsupportedTokens(): { [address: string]: Token } {
   const unsupportedTokensMap = useUnsupportedTokenList()
   return useTokensFromMap(unsupportedTokensMap, false)

--- a/src/hooks/useFeeDisplayCurrency.ts
+++ b/src/hooks/useFeeDisplayCurrency.ts
@@ -1,0 +1,9 @@
+import { AppState } from '../state'
+import { useSelector } from 'react-redux'
+
+export default function useFeeDisplayCurrency(): 'ETH' | 'USD' {
+  const feeDisplayCurrency = useSelector<AppState, AppState['user']['feeDisplayCurrency']>(
+    state => state.user.feeDisplayCurrency
+  )
+  return feeDisplayCurrency
+}

--- a/src/hooks/useLatestGasPrice.ts
+++ b/src/hooks/useLatestGasPrice.ts
@@ -21,7 +21,7 @@ export default function useLatestGasPrice(): BigNumber | undefined {
         return
       }
 
-      setGasPrice(finalTransaction.gasPrice.toString())
+      setGasPrice(finalTransaction.gasPrice?.toString())
     }
     calculateMinerBribe()
   }, [library, currentBlock])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import UserUpdater from './state/user/updater'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from './theme'
 import getLibrary from './utils/getLibrary'
 import { initAnalytics } from './analytics/index'
+import Activity from './state/user/activity'
 
 const Web3ProviderNetwork = createWeb3ReactRoot(NetworkContextName)
 
@@ -36,6 +37,7 @@ function Updaters() {
       <ApplicationUpdater />
       <TransactionUpdater />
       <MulticallUpdater />
+      <Activity />
     </>
   )
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -136,7 +136,7 @@ const StyledButtonError = styled(ButtonError)<{ disabled: boolean }>`
 
   &:before,
   &:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => theme.primary2};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? theme.red1 : theme.primary2)};
     content: '';
     height: 44px;
     position: absolute;
@@ -158,12 +158,12 @@ const StyledButtonError = styled(ButtonError)<{ disabled: boolean }>`
   &:focus:after,
   &:hover:before,
   &:hover:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => darken(0.05, theme.primary2)};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? darken(0.05, theme.red1) : darken(0.05, theme.primary2))};
   }
 
   &:active:before,
   &:active:after {
-    box-shadow: 0 22px 0 0 ${({ theme }) => darken(0.1, theme.primary2)};
+    box-shadow: 0 22px 0 0 ${({ error, theme }) => (error ? darken(0.1, theme.red1) : darken(0.1, theme.primary2))};
   }
 `
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -173,6 +173,7 @@ const StyledButtonYellow = styled(StyledButtonError)`
 `
 
 // Lazy Load
+const NetworkWarningModal = React.lazy(() => import('components/NetworkWarningModal'))
 const TokenWarningModal = React.lazy(() => import('components/TokenWarningModal'))
 const ConfirmInfoModal = React.lazy(() => import('components/swap/ConfirmInfoModal'))
 const ConfirmSwapModal = React.lazy(() => import('components/swap/ConfirmSwapModal'))
@@ -508,6 +509,7 @@ export default function Swap({ history }: RouteComponentProps) {
   return (
     <>
       <Suspense fallback={null}>
+        <NetworkWarningModal />
         <TokenWarningModal
           isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
           tokens={importTokensNotInDefault}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -711,14 +711,13 @@ export default function Swap({ history }: RouteComponentProps) {
                       onClick={swapButtonAction}
                       id="swap-button"
                       disabled={!isValid || (priceImpactSeverity > 3 && !isExpertMode) || !!swapCallbackError}
-                      error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
                     >
                       <Text fontSize={20} fontWeight={700}>
                         {swapInputError
                           ? swapInputError
                           : priceImpactSeverity > 3 && !isExpertMode
                           ? `Price Impact Too High`
-                          : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                          : `Swap`}
                       </Text>
                     </StyledButtonError>
                   )}

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -115,8 +115,6 @@ export function useCombinedActiveList(): TokenAddressMap {
   const activeListUrls = useActiveListUrls()
   const activeTokens = useCombinedTokenMapFromUrls(activeListUrls)
   const defaultTokenMap = listToTokenMap(DEFAULT_TOKEN_LIST)
-  // console.log('activeTokens', activeTokens)
-  // console.log('defaultTokenMap', defaultTokenMap)
   return combineMaps(activeTokens, defaultTokenMap)
 }
 

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -115,6 +115,8 @@ export function useCombinedActiveList(): TokenAddressMap {
   const activeListUrls = useActiveListUrls()
   const activeTokens = useCombinedTokenMapFromUrls(activeListUrls)
   const defaultTokenMap = listToTokenMap(DEFAULT_TOKEN_LIST)
+  // console.log('activeTokens', activeTokens)
+  // console.log('defaultTokenMap', defaultTokenMap)
   return combineMaps(activeTokens, defaultTokenMap)
 }
 
@@ -147,4 +149,16 @@ export function useUnsupportedTokenList(): TokenAddressMap {
 export function useIsListActive(url: string): boolean {
   const activeListUrls = useActiveListUrls()
   return Boolean(activeListUrls?.includes(url))
+}
+
+// return the alchemist token
+export function useAlchmeistToken(chainId: ChainId): any {
+  const list = listToTokenMap(DEFAULT_TOKEN_LIST)
+  const alchemistList = list[chainId]
+  if (!alchemistList) return null
+  const key = Object.keys(alchemistList).find(key => alchemistList[key].token.symbol === 'MIST')
+  if (key && alchemistList[key]) {
+    return alchemistList[key]
+  }
+  return null
 }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -303,7 +303,7 @@ export function useDerivedSwapInfo(): {
   // what do we display if we have multiple inputErrors? (order)
   const ethTrade = isETHTrade(v2Trade)
   if (ethTrade !== undefined && !ethTrade && JSBI.LT(ethBalance?.raw, v2Trade?.minerBribe.raw)) {
-    inputError = 'Insufficient ' + ethBalance?.currency.symbol + ' balance (bribe)'
+    inputError = 'Insufficient ' + ethBalance?.currency.symbol + ' balance (tip)'
   }
 
   return {

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -29,3 +29,4 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
   'user/removeSerializedPair'
 )
 export const toggleURLWarning = createAction<void>('app/toggleURLWarning')
+export const updateFeeDisplayCurrency = createAction<'ETH' | 'USD'>('app/updateFeeDisplayCurrency')

--- a/src/state/user/activity.ts
+++ b/src/state/user/activity.ts
@@ -17,6 +17,7 @@ const Activity = () => {
         }
       }
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return null

--- a/src/state/user/activity.ts
+++ b/src/state/user/activity.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { AppState } from '../index'
+
+const Activity = () => {
+  const lastUpdateVersionTimestamp = useSelector<AppState, AppState['user']['lastUpdateVersionTimestamp']>(
+    state => state.user.lastUpdateVersionTimestamp
+  )
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) {
+        const timeNow = new Date().getTime()
+        const timeDiffMins = Math.floor(Number(lastUpdateVersionTimestamp) - timeNow) / 1000 / 60
+        if (timeDiffMins > 1440) {
+          location.reload()
+        }
+      }
+    })
+  }, [])
+
+  return null
+}
+
+export default Activity

--- a/src/state/user/activity.ts
+++ b/src/state/user/activity.ts
@@ -13,7 +13,7 @@ const Activity = () => {
         const timeNow = new Date().getTime()
         const timeDiffMins = Math.floor(Number(lastUpdateVersionTimestamp) - timeNow) / 1000 / 60
         if (timeDiffMins > 1440) {
-          location.reload()
+          window.location.reload()
         }
       }
     })

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -15,11 +15,11 @@ import {
   updateUserBribeMargin,
   updateUserDeadline,
   toggleURLWarning,
-  updateUserSingleHopOnly
+  updateUserSingleHopOnly,
+  updateFeeDisplayCurrency
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
-
 export interface UserState {
   // the timestamp of the last updateVersion action
   lastUpdateVersionTimestamp?: number
@@ -55,6 +55,7 @@ export interface UserState {
 
   timestamp: number
   URLWarningVisible: boolean
+  feeDisplayCurrency: 'ETH' | 'USD'
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -72,7 +73,8 @@ export const initialState: UserState = {
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp(),
-  URLWarningVisible: true
+  URLWarningVisible: true,
+  feeDisplayCurrency: 'USD'
 }
 
 export default createReducer(initialState, builder =>
@@ -162,5 +164,8 @@ export default createReducer(initialState, builder =>
     })
     .addCase(toggleURLWarning, state => {
       state.URLWarningVisible = !state.URLWarningVisible
+    })
+    .addCase(updateFeeDisplayCurrency, (state, { payload }) => {
+      state.feeDisplayCurrency = payload
     })
 )

--- a/src/utils/trades.ts
+++ b/src/utils/trades.ts
@@ -1,5 +1,5 @@
 import { ZERO_PERCENT, ONE_HUNDRED_PERCENT } from './../constants/index'
-import { Trade, Percent, currencyEquals, ETHER, WETH } from '@alchemistcoin/sdk'
+import { Trade, Percent, currencyEquals, ETHER } from '@alchemistcoin/sdk'
 
 // returns whether tradeB is better than tradeA by at least a threshold percentage amount
 export function isTradeBetter(
@@ -30,12 +30,7 @@ export function isTradeBetter(
 export function isETHTrade(trade: Trade | undefined | null): boolean | undefined {
   if (!trade) {
     return undefined
-  } else if (
-    !currencyEquals(trade.route.input, ETHER) &&
-    !currencyEquals(trade.route.input, WETH[trade.route.chainId]) &&
-    !currencyEquals(trade.route.output, ETHER) &&
-    !currencyEquals(trade.route.output, WETH[trade.route.chainId])
-  ) {
+  } else if (!currencyEquals(trade.route.input, ETHER) && !currencyEquals(trade.route.output, ETHER)) {
     return false
   }
   return true

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -10,6 +10,7 @@ import FATHOM_GOALS from '../constants/fathom'
 // state
 import { updateGas } from '../state/application/actions'
 import { Gas } from '../state/application/reducer'
+import { useSocketStatus } from '../state/application/hooks'
 import {
   useAllTransactions,
   useTransactionRemover,
@@ -162,6 +163,7 @@ export default function Sockets(): null {
   const updateTransaction = useTransactionUpdater()
   const removeTransaction = useTransactionRemover()
   const pendingTransactions = usePendingTransactions()
+  const webSocketConnected = useSocketStatus()
 
   useEffect(() => {
     socket.on('connect', () => {
@@ -268,12 +270,13 @@ export default function Sockets(): null {
     }
   }, [addPopup, dispatch, allTransactions, removeTransaction, updateTransaction])
 
-  // Check each pending transaction every x seconds and fetch an update if the time passed since the last update is more than MANUAL_CHECK_TX_STATUS_INTERVAL (seconds)
+  // Check each pending transaction every 5 seconds and fetch an update if the time passed since the last update is more than MANUAL_CHECK_TX_STATUS_INTERVAL (seconds)
   useEffect(() => {
     let interval: any
     clearInterval(interval)
     if (pendingTransactions) {
       interval = setInterval(() => {
+        if (!webSocketConnected) return
         const timeNow = new Date().getTime()
         Object.keys(pendingTransactions).forEach(hash => {
           const tx = pendingTransactions[hash]
@@ -306,7 +309,7 @@ export default function Sockets(): null {
       clearInterval(interval)
     }
     return () => clearInterval(interval)
-  }, [pendingTransactions, updateTransaction])
+  }, [pendingTransactions, updateTransaction, webSocketConnected])
 
   return null
 }


### PR DESCRIPTION
- mistX balance in header
- fee currency display setting
- ensure slippage is stored correctly
- fix close toggle click bubbling up to reopen the settings menu
- refresh page if idle for more than 24hrs
- show fees in eth for liquidy provider fees and transaction fee
- improved token selection
- minor refactoring / styling fixes