### PR TITLE
v1.3.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemistcoin/mistx-frontend",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "mistX Frontend",
   "homepage": ".",
   "private": true,

--- a/src/api/gasUsed.ts
+++ b/src/api/gasUsed.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+import config from 'config/environment'
+
+const baseUrl = config.ANALYTICS_API_URL
+
+export const getGasUsedForPath = (path: string[]) => {
+  if (!path.includes('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')) {
+    path.splice(1, 0, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')
+  }
+
+  const pathString = path.join('-')
+  return axios.get(`${baseUrl}/gas_used/${pathString}`)
+}

--- a/src/api/rewards.ts
+++ b/src/api/rewards.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { IBackrunTransactionProcessed } from '@alchemist-coin/mistx-connect'
 
 const baseUrl = process.env.REACT_APP_ANALYTICS_API_URL || 'http://localhost:3002'
 
@@ -13,7 +14,7 @@ export interface Reward {
   origin: string
   totalValueETH: number
   totalValueUSD: number
-  transactions: any[]
+  transactions: IBackrunTransactionProcessed[]
   _id: string
 }
 

--- a/src/api/rewards.ts
+++ b/src/api/rewards.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import { IBackrunTransactionProcessed } from '@alchemist-coin/mistx-connect'
+import config from '../config/environment'
 
-const baseUrl = process.env.REACT_APP_ANALYTICS_API_URL || 'http://localhost:3002'
+const baseUrl = config.ANALYTICS_API_URL
 
 const DEFAULT_LIMIT = 16
 const DEFAULT_SKIP = 0

--- a/src/assets/svg/leaderboard-icon.svg
+++ b/src/assets/svg/leaderboard-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" x="100px" y="100px">
+<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 100 100" x="100px" y="100px">
   <g data-name="Award, leaderboard, rank, ranking">
     <rect x="36.12" y="54.34" width="27.05" height="35.66" rx="2.05" />
     <rect x="6.61" y="62.95" width="27.05" height="27.05" rx="2.05" />

--- a/src/components/Rewards/RewardsLeaderboard.tsx
+++ b/src/components/Rewards/RewardsLeaderboard.tsx
@@ -6,6 +6,7 @@ import { CloseIcon, ExternalLink } from 'theme'
 import dayjs from 'dayjs'
 import { getEtherscanLink } from 'utils'
 import { ChainId } from '@alchemist-coin/mistx-core'
+import { keccak256 } from '@ethersproject/keccak256'
 
 const Wrapper = styled.div`
   background-color: ${({ theme }) => rgba(theme.bg1, 0.92)};
@@ -171,22 +172,45 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
         {rewards.map((reward: Reward, index: number) => (
           <RewardItem key={reward._id}>
             <RewardItemCellNumber>{index + 1}.</RewardItemCellNumber>
-            <RewardItemCellDate>{dayjs(reward.transactions[0].timestamp * 1000).format('YY-MM-DD')}</RewardItemCellDate>
+            <RewardItemCellDate>
+              <StyledExternalLink
+                href={getEtherscanLink(
+                  ChainId.MAINNET,
+                  keccak256(reward.transactions[0].serializedOrigin),
+                  'transaction'
+                )}
+              >
+                {reward.transactions[0].timestamp
+                  ? dayjs(reward.transactions[0].timestamp * 1000).format('YYYY-MM-DD')
+                  : 'N/A'}
+              </StyledExternalLink>
+            </RewardItemCellDate>
             <RewardItemCell>
               <StyledExternalLink href={getEtherscanLink(ChainId.MAINNET, reward.from, 'address')}>
                 {`${reward.from.substring(0, 8)}...${reward.from.substring(36)}`}
               </StyledExternalLink>
             </RewardItemCell>
             <RewardItemCellValue>
-              {`${reward.totalValueETH.toFixed(4)}ETH ($${reward.totalValueUSD.toFixed(2)})`}
+              <StyledExternalLink
+                href={getEtherscanLink(
+                  ChainId.MAINNET,
+                  keccak256(reward.transactions[0].serializedBackrun),
+                  'transaction'
+                )}
+              >
+                {`${reward.totalValueETH.toFixed(4)}ETH ($${reward.totalValueUSD.toFixed(2)})`}
+              </StyledExternalLink>
             </RewardItemCellValue>
           </RewardItem>
         ))}
-        {loading && <Loader>...Loading Rewards</Loader>}
-        {rewards.length > 0 && (
-          <LoadMoreButton onClick={loadMoreResults} type="button">
-            Load More Rewards
-          </LoadMoreButton>
+        {loading ? (
+          <Loader>...Loading Rewards</Loader>
+        ) : (
+          rewards.length > 0 && (
+            <LoadMoreButton onClick={loadMoreResults} type="button">
+              Load More Rewards
+            </LoadMoreButton>
+          )
         )}
       </RewardsList>
     </Wrapper>

--- a/src/components/Row/index.tsx
+++ b/src/components/Row/index.tsx
@@ -33,12 +33,13 @@ export const RowFlat = styled.div`
 
 export const AutoRow = styled(Row)<{ gap?: string; justify?: string }>`
   flex-wrap: wrap;
-  margin: ${({ gap }) => gap && `-${gap}`};
+  ${({ gap }) => (gap ? `margin: -${gap};` : '')}
   ${({ justify }) => (justify ? `justify-content: ${justify};` : '')}
-
-  & > * {
-    margin: ${({ gap }) => gap} !important;
-  }
+  ${({ gap }) =>
+    gap &&
+    `& > * {
+      margin: ${gap} !important;
+    }`}
 `
 
 export const RowFixed = styled(Row)<{ gap?: string; justify?: string }>`

--- a/src/components/SideBar/transactions.tsx
+++ b/src/components/SideBar/transactions.tsx
@@ -10,6 +10,11 @@ import { clearCompletedTransactions } from '../../state/transactions/actions'
 import { StyledHeading } from './styled'
 import { ExternalLink } from 'theme'
 import { TransactionDetails } from 'state/transactions/reducer'
+import { MouseoverTooltip } from 'components/Tooltip'
+import { ReactComponent as LeaderboardIcon } from '../../assets/svg/leaderboard-icon.svg'
+import { getEtherscanLink } from 'utils'
+import { ChainId } from '@alchemist-coin/mistx-core'
+import { keccak256 } from '@ethersproject/keccak256'
 
 const StyledContainer = styled.div`
   width: 100%;
@@ -46,12 +51,8 @@ const StyledStatusWapper = styled.div`
 
   svg {
     display: flex;
-    opacity: 60%;
     cursor: pointer;
     margin-left: 6px;
-    path {
-      fill: #fff;
-    }
   }
 `
 
@@ -79,6 +80,26 @@ const StyledExternalLink = styled(ExternalLink)`
 
   :hover {
     color: #fff;
+  }
+`
+
+const StyledLeaderboardIcon = styled(LeaderboardIcon)`
+  fill: ${({ theme }) => theme.secondaryText1};
+  height: 1.25rem;
+  width: 1.25rem;
+
+  path {
+    fill: ${({ theme }) => theme.secondaryText1};
+  }
+`
+
+const StyledQuestionHelper = styled(QuestionHelper)`
+  svg {
+    opacity: 60%;
+  }
+
+  path {
+    fill: #fff;
   }
 `
 
@@ -114,18 +135,36 @@ export default function Transactions() {
               {tx.status === Status.SUCCESSFUL_BUNDLE && (
                 <StyledStatusWapper>
                   <StyledTransactionStatus success={true}>Success</StyledTransactionStatus>
+                  {tx.processed?.backrun && tx.processed?.backrun.best.count > 0 && (
+                    <MouseoverTooltip
+                      text={`Rewards: ${tx.processed.backrun.best.totalValueETH?.toFixed(
+                        4
+                      )}ETH ($${tx.processed.backrun.best.totalValueUSD?.toFixed(2)})`}
+                      placement="top"
+                    >
+                      <ExternalLink
+                        href={getEtherscanLink(
+                          ChainId.MAINNET,
+                          keccak256(tx.processed.backrun.best.transactions[0].serializedBackrun),
+                          'transaction'
+                        )}
+                      >
+                        <StyledLeaderboardIcon />
+                      </ExternalLink>
+                    </MouseoverTooltip>
+                  )}
                 </StyledStatusWapper>
               )}
               {tx.cancel && tx.cancel === Status.CANCEL_BUNDLE_SUCCESSFUL && (
                 <StyledStatusWapper>
                   <StyledTransactionStatus>Cancelled</StyledTransactionStatus>
-                  <QuestionHelper text="Transaction cancelled for free" placement="top" />
+                  <StyledQuestionHelper text="Transaction cancelled for free" placement="top" />
                 </StyledStatusWapper>
               )}
               {(tx.status === Status.FAILED_BUNDLE || tx.status === Status.BUNDLE_NOT_FOUND) && !tx.cancel && (
                 <StyledStatusWapper>
                   <StyledTransactionStatus failed={true}>Failed</StyledTransactionStatus>
-                  {tx.message && <QuestionHelper text={tx.message} placement="top" />}
+                  {tx.message && <StyledQuestionHelper text={tx.message} placement="top" />}
                 </StyledStatusWapper>
               )}
               {tx.status === Status.SUCCESSFUL_BUNDLE ? (

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,0 +1,5 @@
+const config = {
+  ANALYTICS_API_URL: process.env.REACT_APP_ANALYTICS_API_URL || 'http://localhost:3002'
+}
+
+export default config

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -233,8 +233,8 @@ export const NetworkContextName = 'NETWORK'
 
 // default allowed slippage, in bips
 export const INITIAL_ALLOWED_SLIPPAGE = 100
-// 7 minutes, denominated in seconds
-export const DEFAULT_DEADLINE_FROM_NOW = 60 * 5
+// 3 minutes, denominated in seconds
+export const DEFAULT_DEADLINE_FROM_NOW = 60 * 3
 // default min trade margin, in bips
 export const MIN_TRADE_MARGIN = 1
 

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -1,0 +1,33 @@
+import { MISTX_DEFAULT_GAS_LIMIT } from '../constants'
+import { useEffect, useState } from 'react'
+import { getGasUsedForPath } from '../api/gasUsed'
+
+const gasUsed: any = {}
+
+export function useGasLimitForPath(path: string[] | undefined) {
+  const [gasLimit, setGasLimit] = useState((undefined as unknown) as number)
+
+  const str = path && path.join('')
+  useEffect(() => {
+    if (str && path) {
+      if (gasUsed[str]) {
+        setGasLimit(gasUsed[str])
+      } else {
+        getGasUsedForPath(path)
+          .then(response => {
+            console.log('gas for path', response)
+            gasUsed[str] = response.data.gasUsed
+
+            setGasLimit(response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT)
+          })
+          .catch(e => {
+            console.error('error getting gas for path', path, e)
+            setGasLimit(MISTX_DEFAULT_GAS_LIMIT)
+          })
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [str])
+
+  return gasLimit
+}

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -19,14 +19,13 @@ export function useGasLimitForPath(path: string[] | undefined) {
           getGasUsedForPath(path)
             .then(response => {
               delete loading[str]
-              console.log('gas for path', response)
               gasUsed[str] = response.data.gasUsed
 
               setGasLimit(response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT)
             })
             .catch(e => {
               delete loading[str]
-              console.error('error getting gas for path', path, e)
+              // console.error('error getting gas for path', path, e)
               setGasLimit(MISTX_DEFAULT_GAS_LIMIT)
             })
         }

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { getGasUsedForPath } from '../api/gasUsed'
 
 const gasUsed: any = {}
+const loading: any = {}
 
 export function useGasLimitForPath(path: string[] | undefined) {
   const [gasLimit, setGasLimit] = useState((undefined as unknown) as number)
@@ -13,17 +14,22 @@ export function useGasLimitForPath(path: string[] | undefined) {
       if (gasUsed[str]) {
         setGasLimit(gasUsed[str])
       } else {
-        getGasUsedForPath(path)
-          .then(response => {
-            console.log('gas for path', response)
-            gasUsed[str] = response.data.gasUsed
+        if (!loading) {
+          loading[str] = true
+          getGasUsedForPath(path)
+            .then(response => {
+              delete loading[str]
+              console.log('gas for path', response)
+              gasUsed[str] = response.data.gasUsed
 
-            setGasLimit(response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT)
-          })
-          .catch(e => {
-            console.error('error getting gas for path', path, e)
-            setGasLimit(MISTX_DEFAULT_GAS_LIMIT)
-          })
+              setGasLimit(response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT)
+            })
+            .catch(e => {
+              delete loading[str]
+              console.error('error getting gas for path', path, e)
+              setGasLimit(MISTX_DEFAULT_GAS_LIMIT)
+            })
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -14,7 +14,7 @@ export function useGasLimitForPath(path: string[] | undefined) {
       if (gasUsed[str]) {
         setGasLimit(gasUsed[str])
       } else {
-        if (!loading) {
+        if (!loading[str]) {
           loading[str] = true
           getGasUsedForPath(path)
             .then(response => {

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -10,7 +10,7 @@ import isZero from '../utils/isZero'
 import { useActiveWeb3React } from './index'
 import useENS from './useENS'
 import useTransactionDeadline from './useTransactionDeadline'
-import { INITIAL_ALLOWED_SLIPPAGE } from '../constants'
+import { INITIAL_ALLOWED_SLIPPAGE, MISTX_DEFAULT_GAS_LIMIT } from '../constants'
 import { ethers } from 'ethers'
 import { keccak256 } from 'ethers/lib/utils'
 import { SignatureLike } from '@ethersproject/bytes'
@@ -103,7 +103,7 @@ export function useSwapCallback(
             const populatedTx: PopulatedTransaction = await contract.populateTransaction[methodName](...args, {
               //modify nonce if we also have an approval
               nonce: nonce,
-              gasLimit: BigNumber.from(gasLimit),
+              gasLimit: BigNumber.from(gasLimit || MISTX_DEFAULT_GAS_LIMIT),
               type: 2,
               maxFeePerGas: maxBaseFeePerGas,
               maxPriorityFeePerGas: '0x0',

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -1,6 +1,6 @@
 import { PopulatedTransaction } from '@ethersproject/contracts'
 import { BigNumber } from '@ethersproject/bignumber'
-import { Trade, Currency, TradeType } from '@alchemist-coin/mistx-core'
+import { Trade, Currency, TradeType, Token } from '@alchemist-coin/mistx-core'
 import { BundleReq, SwapReq, TransactionReq } from '@alchemist-coin/mistx-connect'
 import { formatUnits } from 'ethers/lib/utils'
 import { useMemo } from 'react'
@@ -48,7 +48,7 @@ export function useSwapCallback(
   const deadline = useTransactionDeadline()
   const { address: recipientAddress } = useENS(recipientAddressOrName)
   const recipient = recipientAddressOrName === null ? account : recipientAddress
-  const gasLimit = useGasLimitForPath(swapCall?.call.parameters.args[0][2])
+  const gasLimit = useGasLimitForPath(trade?.route.path.map((t: Token) => t.address))
   const { maxBaseFeePerGas } = useBaseFeePerGas()
 
   return useMemo(() => {

--- a/src/hooks/useTotalFeesForTrade.ts
+++ b/src/hooks/useTotalFeesForTrade.ts
@@ -2,15 +2,17 @@ import { useMemo } from 'react'
 import { BigNumber } from '@ethersproject/bignumber'
 import useETHPrice from './useEthPrice'
 import useBaseFeePerGas from './useBaseFeePerGas'
-import { Currency, CurrencyAmount, Trade, TradeType, WETH } from '@alchemist-coin/mistx-core'
+import { Currency, CurrencyAmount, Token, Trade, TradeType, WETH } from '@alchemist-coin/mistx-core'
 import { useActiveWeb3React } from 'hooks'
 import { computeTradePriceBreakdown } from 'utils/prices'
+import { useGasLimitForPath } from './useGasLimit'
 
 export default function useTotalFeesForTrade(trade: Trade<Currency, Currency, TradeType>) {
   const { chainId } = useActiveWeb3React()
   const { realizedLPFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const ethPrice = useETHPrice(trade.inputAmount.currency.wrapped)
   const { maxBaseFeePerGas, minBaseFeePerGas, baseFeePerGas } = useBaseFeePerGas()
+  const gasLimit = useGasLimitForPath(trade.route.path.map((t: Token) => t.address))
 
   return useMemo(() => {
     let totalFeeInEth: CurrencyAmount<Currency> | undefined
@@ -28,19 +30,21 @@ export default function useTotalFeesForTrade(trade: Trade<Currency, Currency, Tr
       if (maxBaseFeePerGas && minBaseFeePerGas) {
         maxBaseFeeInEth = CurrencyAmount.fromRawAmount(
           WETH[chainId || 1],
-          BigNumber.from(trade.estimatedGas)
+          BigNumber.from(gasLimit || trade.estimatedGas)
             .mul(maxBaseFeePerGas)
             .toString()
         )
+
+        console.log('GAS LIMIT', gasLimit, trade.estimatedGas)
         minBaseFeeInEth = CurrencyAmount.fromRawAmount(
           WETH[chainId || 1],
-          BigNumber.from(trade.estimatedGas)
+          BigNumber.from(gasLimit || trade.estimatedGas)
             .mul(minBaseFeePerGas)
             .toString()
         )
         baseFeeInEth = CurrencyAmount.fromRawAmount(
           WETH[chainId || 1],
-          BigNumber.from(trade.estimatedGas)
+          BigNumber.from(gasLimit || trade.estimatedGas)
             .mul(BigNumber.from(baseFeePerGas))
             .toString()
         )
@@ -59,6 +63,7 @@ export default function useTotalFeesForTrade(trade: Trade<Currency, Currency, Tr
       totalFeeInEth
     }
   }, [
+    gasLimit,
     maxBaseFeePerGas,
     minBaseFeePerGas,
     chainId,

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -7,7 +7,6 @@ import Footer from '../components/Footer'
 // import URLWarning from '../components/Header/URLWarning'
 import Popups from '../components/Popups'
 import NewAppVersionAvailable from '../components/NewAppVersionAvailable'
-import EIP1559InfoModal from '../components/EIP1559InfoModal'
 import Web3ReactManager from '../components/Web3ReactManager'
 import DarkModeQueryParamReader from '../theme/DarkModeQueryParamReader'
 import Swap from './Swap'
@@ -74,7 +73,6 @@ export default function App() {
         </BodyWrapper>
       </AppWrapper>
       <Popups />
-      <EIP1559InfoModal />
       <NewAppVersionAvailable />
       <ChatWidget />
     </Suspense>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -81,8 +81,12 @@ const StyledAutoRow = styled(AutoRow)`
   > * {
     z-index: 3;
   }
+`
 
-  svg path {
+const StyledArrowWrapper = styled(ArrowWrapper)`
+  align-items: center;
+
+  > svg {
     fill: ${({ theme }) => (theme.darkMode ? theme.yellow1 : theme.bg6)};
   }
 `
@@ -420,7 +424,7 @@ export default function Swap({ history }: RouteComponentProps) {
                   justify={isExpertMode ? 'space-between' : 'center'}
                   style={{ margin: '0.5rem 0 0.5rem', padding: '0 1rem' }}
                 >
-                  <ArrowWrapper
+                  <StyledArrowWrapper
                     clickable
                     color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.primary1 : theme.text2}
                     onClick={() => {
@@ -429,7 +433,7 @@ export default function Swap({ history }: RouteComponentProps) {
                     }}
                   >
                     <ArrowDownCircled data-test="arrow-down" />
-                  </ArrowWrapper>
+                  </StyledArrowWrapper>
                   {recipient === null && !showWrap && isExpertMode ? (
                     <LinkStyledButton id="add-recipient-button" onClick={() => onChangeRecipient('')}>
                       + Add a send (optional)
@@ -462,9 +466,9 @@ export default function Swap({ history }: RouteComponentProps) {
                 {recipient !== null && !showWrap ? (
                   <>
                     <AutoRow justify="space-between" style={{ padding: '0 1rem' }}>
-                      <ArrowWrapper clickable={false}>
+                      <StyledArrowWrapper clickable={false}>
                         <ArrowDownCircled data-test="arrow-down" />
-                      </ArrowWrapper>
+                      </StyledArrowWrapper>
                       <LinkStyledButton id="remove-recipient-button" onClick={() => onChangeRecipient(null)}>
                         - Remove send
                       </LinkStyledButton>

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -223,7 +223,11 @@ export default function Swap({ history }: RouteComponentProps) {
   //   }
   // }, [approval, approvalSubmitted])
 
-  const maxAmountInput: CurrencyAmount<Currency> | undefined = MaxAmountSpend(currencyBalances[Field.INPUT], wrapType, trade)
+  const maxAmountInput: CurrencyAmount<Currency> | undefined = MaxAmountSpend(
+    currencyBalances[Field.INPUT],
+    wrapType,
+    trade
+  )
   const atMaxAmountInput = Boolean(maxAmountInput && parsedAmounts[Field.INPUT]?.equalTo(maxAmountInput))
 
   // the callback to execute the swap

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -223,7 +223,7 @@ export default function Swap({ history }: RouteComponentProps) {
   //   }
   // }, [approval, approvalSubmitted])
 
-  const maxAmountInput: CurrencyAmount<Currency> | undefined = MaxAmountSpend(currencyBalances[Field.INPUT], wrapType)
+  const maxAmountInput: CurrencyAmount<Currency> | undefined = MaxAmountSpend(currencyBalances[Field.INPUT], wrapType, trade)
   const atMaxAmountInput = Boolean(maxAmountInput && parsedAmounts[Field.INPUT]?.equalTo(maxAmountInput))
 
   // the callback to execute the swap

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -19,7 +19,12 @@ import { SwapState } from './reducer'
 import { useUserSlippageTolerance, useUserBribeMargin } from '../user/hooks'
 import { computeSlippageAdjustedAmounts } from '../../utils/prices'
 import { BigNumber } from '@ethersproject/bignumber'
-import { MIN_TRADE_MARGIN, BETTER_TRADE_LESS_HOPS_THRESHOLD, MISTX_DEFAULT_APPROVE_GAS_LIMIT, MISTX_DEFAULT_GAS_LIMIT } from '../../constants'
+import {
+  MIN_TRADE_MARGIN,
+  BETTER_TRADE_LESS_HOPS_THRESHOLD,
+  MISTX_DEFAULT_APPROVE_GAS_LIMIT,
+  MISTX_DEFAULT_GAS_LIMIT
+} from '../../constants'
 import useETHPrice from 'hooks/useEthPrice'
 import { useGasLimitForPath } from 'hooks/useGasLimit'
 

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -19,13 +19,9 @@ import { SwapState } from './reducer'
 import { useUserSlippageTolerance, useUserBribeMargin } from '../user/hooks'
 import { computeSlippageAdjustedAmounts } from '../../utils/prices'
 import { BigNumber } from '@ethersproject/bignumber'
-import {
-  MIN_TRADE_MARGIN,
-  BETTER_TRADE_LESS_HOPS_THRESHOLD,
-  MISTX_DEFAULT_GAS_LIMIT,
-  MISTX_DEFAULT_APPROVE_GAS_LIMIT
-} from '../../constants'
+import { MIN_TRADE_MARGIN, BETTER_TRADE_LESS_HOPS_THRESHOLD, MISTX_DEFAULT_APPROVE_GAS_LIMIT, MISTX_DEFAULT_GAS_LIMIT } from '../../constants'
 import useETHPrice from 'hooks/useEthPrice'
+import { useGasLimitForPath } from 'hooks/useGasLimit'
 
 export function useSwapState(): AppState['swap'] {
   return useSelector<AppState, AppState['swap']>(state => state.swap)
@@ -209,6 +205,7 @@ export function useDerivedSwapInfo(): {
     }
   }
 
+  const gasLimit = useGasLimitForPath(v2Trade?.route.path.map((token: Token) => token.address))
   const rawAmount = useMemo(() => {
     if (v2Trade?.inputAmount.currency.isToken && v2Trade?.inputAmount.currency.isToken) return undefined
 
@@ -324,7 +321,7 @@ export function useDerivedSwapInfo(): {
   if (!inputError) {
     const baseFeeInEth: CurrencyAmount<Currency> = CurrencyAmount.fromRawAmount(
       Ether.onChain(chainId),
-      BigNumber.from(MISTX_DEFAULT_GAS_LIMIT)
+      BigNumber.from(gasLimit || MISTX_DEFAULT_GAS_LIMIT)
         .mul(maxBaseFeePerGas)
         .toString()
     )

--- a/src/state/user/updater.tsx
+++ b/src/state/user/updater.tsx
@@ -30,7 +30,7 @@ export default function Updater(): null {
       if (newBribeMargin && newBribeMargin !== state.userBribeMargin) {
         dispatch(updateUserBribeMargin({ userBribeMargin: newBribeMargin }))
       }
-      const oldDefaultUserDeadline = 60 * 7 // 20 minutes
+      const oldDefaultUserDeadline = 60 * 5 // 5 minutes
       if (state.userDeadline === oldDefaultUserDeadline) {
         dispatch(updateUserDeadline({ userDeadline: DEFAULT_DEADLINE_FROM_NOW }))
       }

--- a/src/utils/maxAmountSpend.ts
+++ b/src/utils/maxAmountSpend.ts
@@ -1,8 +1,9 @@
-import { CurrencyAmount, JSBI, Currency, Ether } from '@alchemist-coin/mistx-core'
+import { CurrencyAmount, JSBI, Currency, Ether, Trade, TradeType, Token } from '@alchemist-coin/mistx-core'
 import { WrapType } from 'hooks/useWrapCallback'
 import { MISTX_DEFAULT_GAS_LIMIT } from '../constants'
 import useBaseFeePerGas from '../hooks/useBaseFeePerGas'
 import { MIN_ETH } from '../constants'
+import { useGasLimitForPath } from 'hooks/useGasLimit'
 
 /**
  * Given some token amount, return the max that can be spent of it
@@ -10,9 +11,12 @@ import { MIN_ETH } from '../constants'
  */
 export function MaxAmountSpend(
   currencyAmount?: CurrencyAmount<Currency>,
-  wrapType?: WrapType
+  wrapType?: WrapType,
+  trade?: Trade<Currency, Currency, TradeType>
 ): CurrencyAmount<Currency> | undefined {
   const { maxBaseFeePerGas } = useBaseFeePerGas()
+  const gasLimit = useGasLimitForPath(trade?.route.path.map((t: Token) => t.address))
+
   if (!currencyAmount) return undefined
   const ETH = Ether.onChain(currencyAmount.currency.chainId)
   if (wrapType !== WrapType.NOT_APPLICABLE) {
@@ -22,7 +26,10 @@ export function MaxAmountSpend(
       return CurrencyAmount.fromRawAmount(ETH, JSBI.BigInt(0))
     }
   } else if (currencyAmount.currency.isNative && maxBaseFeePerGas) {
-    const minETH = JSBI.multiply(JSBI.BigInt(maxBaseFeePerGas.toString()), JSBI.BigInt(MISTX_DEFAULT_GAS_LIMIT))
+    const minETH = JSBI.multiply(
+      JSBI.BigInt(maxBaseFeePerGas.toString()),
+      JSBI.BigInt(gasLimit || MISTX_DEFAULT_GAS_LIMIT)
+    )
     if (JSBI.greaterThan(currencyAmount.quotient, minETH)) {
       return CurrencyAmount.fromRawAmount(ETH, JSBI.subtract(currencyAmount.quotient, minETH))
     } else {


### PR DESCRIPTION
- add rewards icon next to rewarded transactions in transaction list
- add gasUsed endpoint and use it to calculate historic gasLimit for swaps and fee calculations
- fix issue with 'insufficient eth amount' showing when user has enough eth
- reduce default ttl from 5 minutes to 3