### PR TITLE
v1.3.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemistcoin/mistx-frontend",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "mistX Frontend",
   "homepage": ".",
   "private": true,

--- a/src/api/rewards.ts
+++ b/src/api/rewards.ts
@@ -29,3 +29,13 @@ export const getRewards = ({ limit = DEFAULT_LIMIT, skip = DEFAULT_SKIP }: { lim
     params: query
   })
 }
+
+export const getTotalRewards = (address?: string) => {
+  const query = {
+    address
+  }
+
+  return axios.get(`${baseUrl}/rewards/totals`, {
+    params: query
+  })
+}

--- a/src/api/rewards.ts
+++ b/src/api/rewards.ts
@@ -19,11 +19,21 @@ export interface Reward {
   _id: string
 }
 
-export const getRewards = ({ limit = DEFAULT_LIMIT, skip = DEFAULT_SKIP }: { limit?: number; skip?: number } = {}) => {
-  const query = {
+export const getRewards = ({
+  account,
+  limit = DEFAULT_LIMIT,
+  skip = DEFAULT_SKIP
+}: { account?: string; limit?: number; skip?: number } = {}) => {
+  const query: {
+    address?: string
+    limit: number
+    skip: number
+  } = {
     limit,
     skip
   }
+
+  if (account) query.address = account
 
   return axios.get(`${baseUrl}/rewards`, {
     params: query

--- a/src/components/Rewards/RewardsLeaderboard.tsx
+++ b/src/components/Rewards/RewardsLeaderboard.tsx
@@ -406,7 +406,7 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
             href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
               getTweetText({ myRewardsETH, myRewardsUSD, totalRewardsUSD, totalCount: totalRewardsCount })
             )}`}
-            style={{ marginLeft: '1rem' }}
+            style={{ margin: '0 .75rem' }}
           >
             <Twitter size={28} />
           </StyledExternalIconLink>
@@ -482,13 +482,15 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
           </>
         )}
       </Totals>
-      <CheckboxContainer>
-        <CheckboxLabel>
-          <HiddenCheckbox checked={showAccountRewardsOnly} onChange={handleShowMyRewards} />
-          <StyledCheckbox checked={showAccountRewardsOnly}>{showAccountRewardsOnly && <Close />}</StyledCheckbox>
-          <span>Show Only My Rewards</span>
-        </CheckboxLabel>
-      </CheckboxContainer>
+      {account && (
+        <CheckboxContainer>
+          <CheckboxLabel>
+            <HiddenCheckbox checked={showAccountRewardsOnly} onChange={handleShowMyRewards} />
+            <StyledCheckbox checked={showAccountRewardsOnly}>{showAccountRewardsOnly && <Close />}</StyledCheckbox>
+            <span>Show Only My Rewards</span>
+          </CheckboxLabel>
+        </CheckboxContainer>
+      )}
       <RewardsList>
         {rewards.length > 0
           ? rewards.map((reward: Reward, index: number) => (

--- a/src/components/Rewards/RewardsLeaderboard.tsx
+++ b/src/components/Rewards/RewardsLeaderboard.tsx
@@ -129,10 +129,18 @@ const Totals = styled.ul`
   margin: auto;
   max-width: 960px;
   padding: 0 1rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    flex-wrap: wrap;
+  `};
 `
 
 const TotalContainer = styled.li`
   width: 20%;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    width: 40%;
+  `};
 `
 
 const Total = styled.div`
@@ -142,6 +150,11 @@ const Total = styled.div`
   height: 112px;
   justify-content: center;
   padding: 1rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    padding: 0;
+    height: 68px;
+  `};
 `
 
 const TotalReward = styled.div`
@@ -151,15 +164,28 @@ const TotalReward = styled.div`
 
 const TotalCount = styled(TotalReward)`
   font-size: 2rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    font-size: 1.5rem;
+  `};
 `
 
 const ETHReward = styled(TotalReward)`
   font-size: 1.25rem;
   margin-bottom: 1rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    font-size: 1rem;
+    margin-bottom: .5rem;
+  `};
 `
 
 const USDReward = styled(TotalReward)`
   font-size: 1rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    font-size: .75rem;
+  `};
 `
 
 const TotalLabel = styled.h5`
@@ -172,6 +198,12 @@ const TotalLabel = styled.h5`
   margin: 0 0 2rem;
   padding-left: 0.75rem;
   padding-top: 0.75rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-bottom: 1rem;
+    padding-left: .25rem;
+    padding-top: .5rem;
+  `};
 `
 
 const LoaderTotal = styled.div`
@@ -281,7 +313,7 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
             )}
           </Total>
           <TotalLabel>
-            Total Swaps
+            # Total Swaps
             <br />
             With Rewards
           </TotalLabel>
@@ -314,7 +346,7 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
                 )}
               </Total>
               <TotalLabel>
-                {`Times I've`}
+                {`# Times I've`}
                 <br />
                 Been Rewarded
               </TotalLabel>

--- a/src/components/Rewards/RewardsLeaderboard.tsx
+++ b/src/components/Rewards/RewardsLeaderboard.tsx
@@ -104,17 +104,14 @@ const RewardItemCellDate = styled(RewardItemCell)`
 
 const RewardItemCellValue = styled(RewardItemCell)`
   flex: 1;
-  text-align: center;
-
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    text-align: right;
-  `};
+  text-align: right;
 `
 
 const StyledExternalIconLink = styled(ExternalLink)`
   align-items: center;
   color: inherit;
   display: inline-flex;
+  font-family: 'VT323', Arial;
   justify-content: center;
   text-decoration: none;
 
@@ -147,6 +144,7 @@ const Totals = styled.ul`
 
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     flex-wrap: wrap;
+    margin-bottom: 1rem;
   `};
 `
 
@@ -232,9 +230,9 @@ const LoaderTotal = styled.div`
 
 const CheckboxContainer = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   margin: 0 auto;
-  max-width: 720px;
+  max-width: 800px;
   padding: 0 1rem;
 `
 
@@ -398,20 +396,7 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
       <CloseButton>
         <CloseIcon onClick={handleClose} />
       </CloseButton>
-      <Title>
-        Top Rewards.
-        {totalRewardsUSD && totalRewardsCount && (
-          <StyledExternalIconLink
-            className="twitter-share-button"
-            href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-              getTweetText({ myRewardsETH, myRewardsUSD, totalRewardsUSD, totalCount: totalRewardsCount })
-            )}`}
-            style={{ margin: '0 .75rem' }}
-          >
-            <Twitter size={28} />
-          </StyledExternalIconLink>
-        )}
-      </Title>
+      <Title>Top Rewards.</Title>
       <Totals>
         <TotalContainer>
           <Total>
@@ -482,15 +467,30 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
           </>
         )}
       </Totals>
-      {account && (
-        <CheckboxContainer>
-          <CheckboxLabel>
-            <HiddenCheckbox checked={showAccountRewardsOnly} onChange={handleShowMyRewards} />
-            <StyledCheckbox checked={showAccountRewardsOnly}>{showAccountRewardsOnly && <Close />}</StyledCheckbox>
-            <span>Show Only My Rewards</span>
-          </CheckboxLabel>
-        </CheckboxContainer>
-      )}
+      <CheckboxContainer>
+        <div>
+          {account && (
+            <CheckboxLabel>
+              <HiddenCheckbox checked={showAccountRewardsOnly} onChange={handleShowMyRewards} />
+              <StyledCheckbox checked={showAccountRewardsOnly}>{showAccountRewardsOnly && <Close />}</StyledCheckbox>
+              <span>Show Only My Rewards</span>
+            </CheckboxLabel>
+          )}
+        </div>
+        <div>
+          {totalRewardsUSD && totalRewardsCount && (
+            <StyledExternalIconLink
+              className="twitter-share-button"
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
+                getTweetText({ myRewardsETH, myRewardsUSD, totalRewardsUSD, totalCount: totalRewardsCount })
+              )}`}
+            >
+              <Twitter size={20} style={{ marginRight: '.5rem' }} />
+              Share on Twitter
+            </StyledExternalIconLink>
+          )}
+        </div>
+      </CheckboxContainer>
       <RewardsList>
         {rewards.length > 0
           ? rewards.map((reward: Reward, index: number) => (

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -1,6 +1,6 @@
 import { PopulatedTransaction } from '@ethersproject/contracts'
 import { BigNumber } from '@ethersproject/bignumber'
-import { Trade, Currency, TradeType, Token } from '@alchemist-coin/mistx-core'
+import { Trade, Currency, TradeType } from '@alchemist-coin/mistx-core'
 import { BundleReq, SwapReq, TransactionReq } from '@alchemist-coin/mistx-connect'
 import { formatUnits } from 'ethers/lib/utils'
 import { useMemo } from 'react'
@@ -19,7 +19,6 @@ import { useApproveCallbackFromTrade } from './useApproveCallback'
 import { useSwapCallArguments } from './useSwapCallArguments'
 import useBaseFeePerGas from './useBaseFeePerGas'
 import { emitTransactionRequest } from '../websocket'
-import { useGasLimitForPath } from './useGasLimit'
 
 export enum SwapCallbackState {
   INVALID,
@@ -48,7 +47,6 @@ export function useSwapCallback(
   const deadline = useTransactionDeadline()
   const { address: recipientAddress } = useENS(recipientAddressOrName)
   const recipient = recipientAddressOrName === null ? account : recipientAddress
-  const gasLimit = useGasLimitForPath(trade?.route.path.map((t: Token) => t.address))
   const { maxBaseFeePerGas } = useBaseFeePerGas()
 
   return useMemo(() => {
@@ -103,7 +101,7 @@ export function useSwapCallback(
             const populatedTx: PopulatedTransaction = await contract.populateTransaction[methodName](...args, {
               //modify nonce if we also have an approval
               nonce: nonce,
-              gasLimit: BigNumber.from(gasLimit || MISTX_DEFAULT_GAS_LIMIT),
+              gasLimit: BigNumber.from(MISTX_DEFAULT_GAS_LIMIT),
               type: 2,
               maxFeePerGas: maxBaseFeePerGas,
               maxPriorityFeePerGas: '0x0',
@@ -274,7 +272,6 @@ export function useSwapCallback(
     library,
     account,
     chainId,
-    gasLimit,
     recipient,
     recipientAddressOrName,
     swapCall,


### PR DESCRIPTION
- add 'total rewards' and 'my rewards' to rewards leaderboard
- share to twitter button on rewards page
- ability to filter rewards by users address
- revert to use mistx_default_gas_limit when swapping