### PR TITLE
v1.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemistcoin/mistx-frontend",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "mistX Frontend",
   "homepage": ".",
   "private": true,

--- a/src/components/Rewards/RewardsLeaderboard.tsx
+++ b/src/components/Rewards/RewardsLeaderboard.tsx
@@ -331,7 +331,6 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
         setMyRewardsETH(myRewards.data.totals.totalValueETH)
         setMyRewardsUSD(myRewards.data.totals.totalValueUSD)
       }
-      console.log('total rewards', totalRewards, myRewards)
     } catch (e) {
       console.error('Error getting rewards', e)
     }
@@ -358,8 +357,6 @@ export default function RewardsLeaderboard({ onClose }: { onClose: () => void })
       const response = await getRewards({
         skip: rewards.length
       })
-
-      console.log('response', response)
 
       setRewards([...rewards, ...response.data])
     } catch (e) {

--- a/src/hooks/useApproveCallback.ts
+++ b/src/hooks/useApproveCallback.ts
@@ -5,7 +5,7 @@ import { useTokenAllowance } from '../data/Allowances'
 import { Field } from '../state/swap/actions'
 import { useHasPendingApproval } from '../state/transactions/hooks'
 import { computeSlippageAdjustedAmounts } from '../utils/prices'
-import { calculateGasMargin } from '../utils'
+import { BigNumber } from '@ethersproject/bignumber'
 import { useTokenContract } from './useContract'
 import { useActiveWeb3React } from './index'
 import useBaseFeePerGas from './useBaseFeePerGas'
@@ -123,7 +123,7 @@ export function useApproveCallback(
         amountToApprove.quotient.toString(),
         {
           nonce: nonce,
-          gasLimit: calculateGasMargin(estimatedGas), //needed?
+          gasLimit: estimatedGas.mul(BigNumber.from(10000).add(BigNumber.from(1000))).div(BigNumber.from(10000)), // add 10%
           type: 2,
           maxFeePerGas: maxBaseFeePerGas,
           maxPriorityFeePerGas: '0x0'

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -1,38 +1,54 @@
 import { MISTX_DEFAULT_GAS_LIMIT } from '../constants'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { getGasUsedForPath } from '../api/gasUsed'
+import { setGasLimitForPath } from 'state/application/actions'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppState } from '../state'
 
 const gasUsed: any = {}
 const loading: any = {}
 
 export function useGasLimitForPath(path: string[] | undefined) {
-  const [gasLimit, setGasLimit] = useState((undefined as unknown) as number)
+  const dispatch = useDispatch()
+  const gasLimits = useSelector<AppState, AppState['application']['gasLimits']>(state => state.application.gasLimits)
 
   const str = path && path.join('')
   useEffect(() => {
-    if (str && path) {
-      if (gasUsed[str]) {
-        setGasLimit(gasUsed[str])
-      } else {
-        if (!loading[str]) {
-          loading[str] = true
-          getGasUsedForPath(path)
-            .then(response => {
-              delete loading[str]
-              gasUsed[str] = response.data.gasUsed
+    let isCancelled = false
 
-              setGasLimit(response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT)
-            })
-            .catch(e => {
-              delete loading[str]
-              // console.error('error getting gas for path', path, e)
-              setGasLimit(MISTX_DEFAULT_GAS_LIMIT)
-            })
-        }
+    async function getGasLimit(str: string, path: string[]) {
+      try {
+        const response = await getGasUsedForPath(path)
+
+        if (isCancelled) return
+
+        delete loading[str]
+        gasUsed[str] = response.data.gasUsed
+        dispatch(setGasLimitForPath({ path: str, gasLimit: response.data.gasUsed || MISTX_DEFAULT_GAS_LIMIT }))
+        return
+      } catch (e) {
+        if (isCancelled) return
+
+        delete loading[str]
+        console.error('error getting gas for path', path, e)
+        dispatch(setGasLimitForPath({ path: str, gasLimit: MISTX_DEFAULT_GAS_LIMIT }))
+        return
       }
+    }
+
+    if (str && path) {
+      if (!loading[str] && !gasLimits[str]) {
+        loading[str] = true
+        getGasLimit(str, path)
+      }
+    }
+
+    return () => {
+      isCancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [str])
 
-  return gasLimit
+  return MISTX_DEFAULT_GAS_LIMIT
+  // return str ? gasLimits[str] : MISTX_DEFAULT_GAS_LIMIT
 }

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -49,6 +49,5 @@ export function useGasLimitForPath(path: string[] | undefined) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [str])
 
-  return MISTX_DEFAULT_GAS_LIMIT
-  // return str ? gasLimits[str] : MISTX_DEFAULT_GAS_LIMIT
+  return str ? gasLimits[str] : MISTX_DEFAULT_GAS_LIMIT
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -46,6 +46,7 @@ import { computeTradePriceBreakdown } from '../../utils/prices'
 import { LinkStyledButton } from '../../theme'
 import FATHOM_GOALS from '../../constants/fathom'
 import SwapFooter from '../../components/swap/SwapFooter'
+import { useGasLimitForPath } from 'hooks/useGasLimit'
 
 const SwapWrapper = styled.div`
   background: #2a3645;
@@ -230,11 +231,14 @@ export default function Swap({ history }: RouteComponentProps) {
   )
   const atMaxAmountInput = Boolean(maxAmountInput && parsedAmounts[Field.INPUT]?.equalTo(maxAmountInput))
 
+  const gasLimit = useGasLimitForPath(trade?.route.path.map((t: Token) => t.address))
+
   // the callback to execute the swap
   const { callback: swapCallback, error: swapCallbackError } = useSwapCallback(
     trade,
     allowedSlippage,
-    recipient
+    recipient,
+    gasLimit
     //transactionTTL
   )
 

--- a/src/state/application/actions.ts
+++ b/src/state/application/actions.ts
@@ -48,4 +48,4 @@ export const removePopup = createAction<{ key: string }>('application/removePopu
 export const updateSocketStatus = createAction<boolean>('application/updateSocketStatus')
 export const updateNewAppVersionAvailable = createAction<boolean>('application/updateNewAppVersionAvailable')
 export const toggleSideBar = createAction('application/toggleSideBar')
-export const setGasLimitForPath = createAction<{ path: string, gasLimit: number }>('application/setGasLimit')
+export const setGasLimitForPath = createAction<{ path: string; gasLimit: number }>('application/setGasLimit')

--- a/src/state/application/actions.ts
+++ b/src/state/application/actions.ts
@@ -48,3 +48,4 @@ export const removePopup = createAction<{ key: string }>('application/removePopu
 export const updateSocketStatus = createAction<boolean>('application/updateSocketStatus')
 export const updateNewAppVersionAvailable = createAction<boolean>('application/updateNewAppVersionAvailable')
 export const toggleSideBar = createAction('application/toggleSideBar')
+export const setGasLimitForPath = createAction<{ path: string, gasLimit: number }>('application/setGasLimit')

--- a/src/state/application/reducer.ts
+++ b/src/state/application/reducer.ts
@@ -10,7 +10,8 @@ import {
   setOpenModal,
   updateSocketStatus,
   updateNewAppVersionAvailable,
-  toggleSideBar
+  toggleSideBar,
+  setGasLimitForPath
 } from './actions'
 
 type PopupList = Array<{ key: string; show: boolean; content: PopupContent; removeAfterMs: number | null }>
@@ -22,6 +23,9 @@ export interface ApplicationState {
   readonly socketStatus: boolean
   readonly newAppVersionAvailable: boolean
   readonly sideBarOpen: boolean
+  readonly gasLimits: {
+    [path: string]: number
+  }
 }
 
 const initialState: ApplicationState = {
@@ -31,7 +35,8 @@ const initialState: ApplicationState = {
   fees: undefined,
   socketStatus: true,
   newAppVersionAvailable: false,
-  sideBarOpen: false
+  sideBarOpen: false,
+  gasLimits: {}
 }
 
 export default createReducer(initialState, builder =>
@@ -76,5 +81,8 @@ export default createReducer(initialState, builder =>
     })
     .addCase(toggleSideBar, state => {
       state.sideBarOpen = !state.sideBarOpen
+    })
+    .addCase(setGasLimitForPath, (state, { payload }) => {
+      state.gasLimits[payload.path] = payload.gasLimit
     })
 )

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -87,8 +87,8 @@ describe('utils', () => {
 
   describe('#calculateGasMargin', () => {
     it('adds 10%', () => {
-      expect(calculateGasMargin(BigNumber.from(1000)).toString()).toEqual('1100')
-      expect(calculateGasMargin(BigNumber.from(50)).toString()).toEqual('55')
+      expect(calculateGasMargin(BigNumber.from(1000)).toString()).toEqual('1300')
+      expect(calculateGasMargin(BigNumber.from(100)).toString()).toEqual('130')
     })
   })
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,7 +71,7 @@ export function shortenAddress(address: string, chars = 4): string {
 
 // add 10%
 export function calculateGasMargin(value: BigNumber): BigNumber {
-  return value.mul(BigNumber.from(10000).add(BigNumber.from(1000))).div(BigNumber.from(10000))
+  return value.mul(BigNumber.from(10000).add(BigNumber.from(3000))).div(BigNumber.from(10000))
 }
 
 // converts a basis points value to a sdk percent


### PR DESCRIPTION
- Increase calculated gas margin for gas limit from +10% to +30%
- Keep approval gas limit +10%
- add a check to make sure base fee is defined prior to allowing swap
- Move the gasLimit returned from gasLimitPerPath to the reducer from the hook's state. Hook was not properly updating state when async response was returned